### PR TITLE
Initial support for v2 API

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -34,6 +34,16 @@
             'src/spellchecker_hunspell.cc',
           ],
         }],
+        ['OS=="win"', {
+          'sources': [
+             'src/spellchecker_win.cc'
+          ],
+        }],
+        ['OS=="linux"', {
+          'sources': [
+             'src/spellchecker_linux.cc'
+          ],
+        }],
         ['OS=="mac" and spellchecker_use_hunspell=="false"', {
           'sources': [
             'src/spellchecker_mac.mm',

--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -11,16 +11,16 @@ var ensureDefaultSpellCheck = function() {
   defaultSpellcheck.setDictionary('en_US', path.join(__dirname, '..', 'vendor', 'hunspell_dictionaries'));
 };
 
-var isMisspelled = function(word) {
+var isMisspelled = function() {
   ensureDefaultSpellCheck();
 
-  return defaultSpellcheck.isMisspelled(word);
+  return defaultSpellcheck.isMisspelled.apply(defaultSpellcheck, arguments);
 };
 
-var getCorrectionsForMisspelling = function(word) {
+var getCorrectionsForMisspelling = function() {
   ensureDefaultSpellCheck();
 
-  return defaultSpellcheck.getCorrectionsForMisspelling(word);
+  return defaultSpellcheck.getCorrectionsForMisspelling.apply(defaultSpellcheck, arguments);
 };
 
 module.exports = {

--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -3,5 +3,6 @@ bindings.init(__dirname);
 
 module.exports = {
   isMisspelled: bindings.isMisspelled,
-  getCorrectionsForMisspelling: bindings.getCorrectionsForMisspelling
+  getCorrectionsForMisspelling: bindings.getCorrectionsForMisspelling,
+  TestClass: bindings.TestClass
 };

--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -1,8 +1,30 @@
+var path = require('path');
 var bindings = require('../build/Release/spellchecker.node');
-bindings.init(__dirname);
+
+Spellchecker = bindings.Spellchecker;
+
+var defaultSpellcheck = null;
+var ensureDefaultSpellCheck = function() {
+  if (defaultSpellcheck) return;
+
+  defaultSpellcheck = new Spellchecker();
+  defaultSpellcheck.setDictionary('en_US', path.join(__dirname, '..', 'vendor', 'hunspell_dictionaries'));
+};
+
+var isMisspelled = function(word) {
+  ensureDefaultSpellCheck();
+
+  return defaultSpellcheck.isMisspelled(word);
+};
+
+var getCorrectionsForMisspelling = function(word) {
+  ensureDefaultSpellCheck();
+
+  return defaultSpellcheck.getCorrectionsForMisspelling(word);
+};
 
 module.exports = {
-  isMisspelled: bindings.isMisspelled,
-  getCorrectionsForMisspelling: bindings.getCorrectionsForMisspelling,
-  TestClass: bindings.TestClass
+  isMisspelled: isMisspelled,
+  getCorrectionsForMisspelling: getCorrectionsForMisspelling,
+  Spellchecker: Spellchecker
 };

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,49 +1,97 @@
-#include "spellchecker.h"
-
 #include "nan.h"
+#include "spellchecker.h"
+#include "spellchecker_hunspell.h"
+
+using node::ObjectWrap;
+using namespace spellchecker;
 using namespace v8;
 
 namespace {
 
-NAN_METHOD(PlatformInit) {
-  NanScope();
-  spellchecker::Init(*String::Utf8Value(args[0]));
-  NanReturnUndefined();
-}
+class Spellchecker : public ObjectWrap {
+  SpellcheckerImplementation* impl;
 
-NAN_METHOD(IsMisspelled) {
-  NanScope();
-  if (args.Length() < 1)
-    return NanThrowError("Bad argument");
+  static NAN_METHOD(New) {
+    NanScope();
+    Spellchecker* that = new Spellchecker();
+    that->Wrap(args.This());
 
-  std::string word = *String::Utf8Value(args[0]);
-  NanReturnValue(NanNew<Boolean>(spellchecker::IsMisspelled(word)));
-}
-
-NAN_METHOD(GetCorrectionsForMisspelling) {
-  NanScope();
-  if (args.Length() < 1)
-    return NanThrowError("Bad argument");
-
-  std::string word = *String::Utf8Value(args[0]);
-  std::vector<std::string> corrections =
-    spellchecker::GetCorrectionsForMisspelling(word);
-
-  Local<Array> result = NanNew<Array>(corrections.size());
-  for (size_t i = 0; i < corrections.size(); ++i) {
-    const std::string& word = corrections[i];
-    result->Set(i, NanNew<String>(word.data(), word.size()));
+    NanReturnValue(args.This());
   }
 
-  NanReturnValue(result);
-}
+  static NAN_METHOD(SetDictionaryDirectory) {
+    NanScope();
 
-void Init(Handle<Object> exports) {
-  NODE_SET_METHOD(exports, "init", PlatformInit);
-  NODE_SET_METHOD(exports, "isMisspelled", IsMisspelled);
-  NODE_SET_METHOD(exports,
-                  "getCorrectionsForMisspelling",
-                  GetCorrectionsForMisspelling);
+    if (args.Length() < 1) {
+      return NanThrowError("Bad argument");
+    }
+
+    Spellchecker* that = ObjectWrap::Unwrap<Spellchecker>(args.Holder());
+    std::string directory = *String::Utf8Value(args[0]);
+    that->impl->SetDictionaryDirectory(directory);
+    NanReturnUndefined();
+  }
+
+  static NAN_METHOD(IsMisspelled) {
+    NanScope();
+    if (args.Length() < 1) {
+      return NanThrowError("Bad argument");
+    }
+
+    Spellchecker* that = ObjectWrap::Unwrap<Spellchecker>(args.Holder());
+    std::string word = *String::Utf8Value(args[0]);
+
+    NanReturnValue(NanNew<Boolean>(that->impl->IsMisspelled(word)));
+  }
+
+  static NAN_METHOD(GetCorrectionsForMisspelling) {
+    NanScope();
+    if (args.Length() < 1) {
+      return NanThrowError("Bad argument");
+    }
+
+    Spellchecker* that = ObjectWrap::Unwrap<Spellchecker>(args.Holder());
+
+    std::string word = *String::Utf8Value(args[0]);
+    std::vector<std::string> corrections =
+      that->impl->GetCorrectionsForMisspelling(word);
+
+    Local<Array> result = NanNew<Array>(corrections.size());
+    for (size_t i = 0; i < corrections.size(); ++i) {
+      const std::string& word = corrections[i];
+      result->Set(i, NanNew<String>(word.data(), word.size()));
+    }
+
+    NanReturnValue(result);
+  }
+
+  Spellchecker() {
+    // TODO: Set impl
+    impl = new HunspellSpellchecker();
+  }
+
+  // actual destructor
+  virtual ~Spellchecker() {
+    delete impl;
+  }
+
+ public:
+  static void Init(Handle<Object> exports) {
+    Local<FunctionTemplate> tpl = NanNew<FunctionTemplate>(Spellchecker::New);
+
+    tpl->SetClassName(NanSymbol("Spellchecker"));
+    tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+    NODE_SET_METHOD(tpl->InstanceTemplate(), "setDictionaryDirectory", Spellchecker::SetDictionaryDirectory);
+    NODE_SET_METHOD(tpl->InstanceTemplate(), "getCorrectionsForMisspelling", Spellchecker::GetCorrectionsForMisspelling);
+    NODE_SET_METHOD(tpl->InstanceTemplate(), "isMisspelled", Spellchecker::IsMisspelled);
+
+    exports->Set(NanNew("Spellchecker"), tpl->GetFunction());
+  }
+};
+
+void Init(Handle<Object> exports, Handle<Object> module) {
+  Spellchecker::Init(exports);
 }
 
 }  // namespace

--- a/src/main.cc
+++ b/src/main.cc
@@ -19,7 +19,7 @@ class Spellchecker : public ObjectWrap {
     NanReturnValue(args.This());
   }
 
-  static NAN_METHOD(SetDictionaryDirectory) {
+  static NAN_METHOD(SetDictionary) {
     NanScope();
 
     if (args.Length() < 1) {
@@ -27,8 +27,14 @@ class Spellchecker : public ObjectWrap {
     }
 
     Spellchecker* that = ObjectWrap::Unwrap<Spellchecker>(args.Holder());
-    std::string directory = *String::Utf8Value(args[0]);
-    that->impl->SetDictionaryDirectory(directory);
+
+    std::string language = *String::Utf8Value(args[0]);
+    std::string directory = "";
+    if (args.Length() > 1) {
+      directory = *String::Utf8Value(args[1]);
+    }
+
+    that->impl->SetDictionary(language, directory);
     NanReturnUndefined();
   }
 
@@ -82,7 +88,7 @@ class Spellchecker : public ObjectWrap {
     tpl->SetClassName(NanSymbol("Spellchecker"));
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-    NODE_SET_METHOD(tpl->InstanceTemplate(), "setDictionaryDirectory", Spellchecker::SetDictionaryDirectory);
+    NODE_SET_METHOD(tpl->InstanceTemplate(), "setDictionary", Spellchecker::SetDictionary);
     NODE_SET_METHOD(tpl->InstanceTemplate(), "getCorrectionsForMisspelling", Spellchecker::GetCorrectionsForMisspelling);
     NODE_SET_METHOD(tpl->InstanceTemplate(), "isMisspelled", Spellchecker::IsMisspelled);
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,6 +1,5 @@
 #include "nan.h"
 #include "spellchecker.h"
-#include "spellchecker_hunspell.h"
 
 using node::ObjectWrap;
 using namespace spellchecker;
@@ -72,8 +71,7 @@ class Spellchecker : public ObjectWrap {
   }
 
   Spellchecker() {
-    // TODO: Set impl
-    impl = new HunspellSpellchecker();
+    impl = SpellcheckerFactory::CreateSpellchecker();
   }
 
   // actual destructor

--- a/src/main.cc
+++ b/src/main.cc
@@ -28,7 +28,7 @@ class Spellchecker : public ObjectWrap {
     Spellchecker* that = ObjectWrap::Unwrap<Spellchecker>(args.Holder());
 
     std::string language = *String::Utf8Value(args[0]);
-    std::string directory = "";
+    std::string directory = ".";
     if (args.Length() > 1) {
       directory = *String::Utf8Value(args[1]);
     }

--- a/src/spellchecker.h
+++ b/src/spellchecker.h
@@ -8,7 +8,7 @@ namespace spellchecker {
 
 class SpellcheckerImplementation {
 public:
-  virtual void SetDictionaryDirectory(const std::string& path) = 0;
+  virtual void SetDictionary(const std::string& language, const std::string& path) = 0;
 
   // Returns an array containing possible corrections for the word.
   virtual std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word) = 0;

--- a/src/spellchecker.h
+++ b/src/spellchecker.h
@@ -19,6 +19,11 @@ public:
   virtual ~SpellcheckerImplementation() {}
 };
 
+class SpellcheckerFactory {
+public:
+  static SpellcheckerImplementation* CreateSpellchecker();
+};
+
 }  // namespace spellchecker
 
 #endif  // SRC_SPELLCHECKER_H_

--- a/src/spellchecker.h
+++ b/src/spellchecker.h
@@ -6,14 +6,16 @@
 
 namespace spellchecker {
 
-// Initializes everything.
-void Init(const std::string& dirname);
+class SpellcheckerImplementation {
+public:
+  virtual void SetDictionaryDirectory(const std::string& path) = 0;
 
-// Returns true if the word is misspelled.
-bool IsMisspelled(const std::string& word);
+  // Returns an array containing possible corrections for the word.
+  virtual std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word) = 0;
 
-// Returns an array containing possible corrections for the word.
-std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
+  // Returns true if the word is misspelled.
+  virtual bool IsMisspelled(const std::string& word) = 0;
+};
 
 }  // namespace spellchecker
 

--- a/src/spellchecker.h
+++ b/src/spellchecker.h
@@ -15,6 +15,8 @@ public:
 
   // Returns true if the word is misspelled.
   virtual bool IsMisspelled(const std::string& word) = 0;
+
+  virtual ~SpellcheckerImplementation();
 };
 
 }  // namespace spellchecker

--- a/src/spellchecker.h
+++ b/src/spellchecker.h
@@ -16,7 +16,7 @@ public:
   // Returns true if the word is misspelled.
   virtual bool IsMisspelled(const std::string& word) = 0;
 
-  virtual ~SpellcheckerImplementation();
+  virtual ~SpellcheckerImplementation() {}
 };
 
 }  // namespace spellchecker

--- a/src/spellchecker_hunspell.cc
+++ b/src/spellchecker_hunspell.cc
@@ -1,38 +1,44 @@
-#include "spellchecker_hunspell.h"
-
 #include "../vendor/hunspell/src/hunspell/hunspell.hxx"
+
+#include "spellchecker_hunspell.h"
 
 namespace spellchecker {
 
-namespace {
+HunspellSpellchecker::HunspellSpellchecker() {
+  this->hunspell = NULL;
+}
 
-Hunspell* g_hunspell = NULL;
+HunspellSpellchecker::~HunspellSpellchecker() {
+  if (!this->hunspell) return;
 
-}  // namespace
+  delete this->hunspell;
+}
 
 void HunspellSpellchecker::SetDictionary(const std::string& language, const std::string& dirname) {
-  if (g_hunspell != NULL)
-    return;
+  if (hunspell != NULL) {
+    delete this->hunspell;
+  }
 
-  std::string affixpath = dirname + "/../vendor/hunspell_dictionaries/en_US.aff";
-  std::string dpath = dirname + "/../vendor/hunspell_dictionaries/en_US.dic";
-  g_hunspell = new Hunspell(affixpath.c_str(), dpath.c_str());
+  std::string affixpath = dirname + "/" + language + ".aff";
+  std::string dpath = dirname + "/" + language + ".dic";
+  this->hunspell = new Hunspell(affixpath.c_str(), dpath.c_str());
 }
 
 bool HunspellSpellchecker::IsMisspelled(const std::string& word) {
-  return g_hunspell->spell(word.c_str()) == 0;
+  return this->hunspell->spell(word.c_str()) == 0;
 }
 
 std::vector<std::string> HunspellSpellchecker::GetCorrectionsForMisspelling(const std::string& word) {
   std::vector<std::string> corrections;
   char** slist;
-  int size = g_hunspell->suggest(&slist, word.c_str());
+  int size = hunspell->suggest(&slist, word.c_str());
 
   corrections.reserve(size);
-  for (int i = 0; i < size; ++i)
+  for (int i = 0; i < size; ++i) {
     corrections.push_back(slist[i]);
+  }
 
-  g_hunspell->free_list(&slist, size);
+  this->hunspell->free_list(&slist, size);
   return corrections;
 }
 

--- a/src/spellchecker_hunspell.cc
+++ b/src/spellchecker_hunspell.cc
@@ -1,4 +1,4 @@
-#include "spellchecker.h"
+#include "spellchecker_hunspell.h"
 
 #include "../vendor/hunspell/src/hunspell/hunspell.hxx"
 
@@ -10,7 +10,7 @@ Hunspell* g_hunspell = NULL;
 
 }  // namespace
 
-void Init(const std::string& dirname) {
+void HunspellSpellchecker::SetDictionaryDirectory(const std::string& dirname) {
   if (g_hunspell != NULL)
     return;
 
@@ -19,11 +19,11 @@ void Init(const std::string& dirname) {
   g_hunspell = new Hunspell(affixpath.c_str(), dpath.c_str());
 }
 
-bool IsMisspelled(const std::string& word) {
+bool HunspellSpellchecker::IsMisspelled(const std::string& word) {
   return g_hunspell->spell(word.c_str()) == 0;
 }
 
-std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word) {
+std::vector<std::string> HunspellSpellchecker::GetCorrectionsForMisspelling(const std::string& word) {
   std::vector<std::string> corrections;
   char** slist;
   int size = g_hunspell->suggest(&slist, word.c_str());

--- a/src/spellchecker_hunspell.cc
+++ b/src/spellchecker_hunspell.cc
@@ -10,7 +10,7 @@ Hunspell* g_hunspell = NULL;
 
 }  // namespace
 
-void HunspellSpellchecker::SetDictionaryDirectory(const std::string& dirname) {
+void HunspellSpellchecker::SetDictionary(const std::string& language, const std::string& dirname) {
   if (g_hunspell != NULL)
     return;
 

--- a/src/spellchecker_hunspell.h
+++ b/src/spellchecker_hunspell.h
@@ -3,13 +3,21 @@
 
 #include "spellchecker.h"
 
+class Hunspell;
+
 namespace spellchecker {
 
 class HunspellSpellchecker : public SpellcheckerImplementation {
 public:
+  HunspellSpellchecker();
+  ~HunspellSpellchecker();
+
   void SetDictionary(const std::string& language, const std::string& path);
   std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
   bool IsMisspelled(const std::string& word);
+
+private:
+  Hunspell* hunspell;
 };
 
 }  // namespace spellchecker

--- a/src/spellchecker_hunspell.h
+++ b/src/spellchecker_hunspell.h
@@ -7,7 +7,7 @@ namespace spellchecker {
 
 class HunspellSpellchecker : public SpellcheckerImplementation {
 public:
-  void SetDictionaryDirectory(const std::string& path);
+  void SetDictionary(const std::string& language, const std::string& path);
   std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
   bool IsMisspelled(const std::string& word);
 };

--- a/src/spellchecker_hunspell.h
+++ b/src/spellchecker_hunspell.h
@@ -1,0 +1,17 @@
+#ifndef SRC_SPELLCHECKER_HUNSPELL_H_
+#define SRC_SPELLCHECKER_HUNSPELL_H_
+
+#include "spellchecker.h"
+
+namespace spellchecker {
+
+class HunspellSpellchecker : public SpellcheckerImplementation {
+public:
+  void SetDictionaryDirectory(const std::string& path);
+  std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
+  bool IsMisspelled(const std::string& word);
+};
+
+}  // namespace spellchecker
+
+#endif  // SRC_SPELLCHECKER_MAC_H_

--- a/src/spellchecker_linux.cc
+++ b/src/spellchecker_linux.cc
@@ -1,0 +1,10 @@
+#include "spellchecker.h"
+#include "spellchecker_hunspell.h"
+
+namespace spellchecker {
+
+SpellcheckerImplementation* SpellcheckerFactory::CreateSpellchecker() {
+  return new HunspellSpellchecker();
+}
+
+}  // namespace spellchecker

--- a/src/spellchecker_mac.h
+++ b/src/spellchecker_mac.h
@@ -1,0 +1,17 @@
+#ifndef SRC_SPELLCHECKER_MAC_H_
+#define SRC_SPELLCHECKER_MAC_H_
+
+#include "spellchecker.h"
+
+namespace spellchecker {
+
+class MacSpellchecker : public SpellcheckerImplementation {
+public:
+  void SetDictionaryDirectory(const std::string& path);
+  std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
+  bool IsMisspelled(const std::string& word);
+};
+
+}  // namespace spellchecker
+
+#endif  // SRC_SPELLCHECKER_MAC_H_

--- a/src/spellchecker_mac.h
+++ b/src/spellchecker_mac.h
@@ -7,7 +7,7 @@ namespace spellchecker {
 
 class MacSpellchecker : public SpellcheckerImplementation {
 public:
-  void SetDictionaryDirectory(const std::string& path);
+  void SetDictionary(const std::string& language, const std::string& path);
   std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
   bool IsMisspelled(const std::string& word);
 };

--- a/src/spellchecker_mac.mm
+++ b/src/spellchecker_mac.mm
@@ -47,4 +47,8 @@ std::vector<std::string> MacSpellchecker::GetCorrectionsForMisspelling(const std
   return corrections;
 }
 
+SpellcheckerImplementation* SpellcheckerFactory::CreateSpellchecker() {
+  return new MacSpellchecker();
+}
+
 }  // namespace spellchecker

--- a/src/spellchecker_mac.mm
+++ b/src/spellchecker_mac.mm
@@ -5,7 +5,7 @@
 
 namespace spellchecker {
 
-void MacSpellchecker::SetDictionaryDirectory(const std::string& path) {
+void MacSpellchecker::SetDictionary(const std::string& language, const std::string& path) {
 }
 
 bool MacSpellchecker::IsMisspelled(const std::string& word) {

--- a/src/spellchecker_mac.mm
+++ b/src/spellchecker_mac.mm
@@ -1,14 +1,14 @@
-#include "spellchecker.h"
+#include "spellchecker_mac.h"
 
 #import <Cocoa/Cocoa.h>
 #import <dispatch/dispatch.h>
 
 namespace spellchecker {
 
-void Init(const std::string& dirname) {
+void MacSpellchecker::SetDictionaryDirectory(const std::string& path) {
 }
 
-bool IsMisspelled(const std::string& word) {
+bool MacSpellchecker::IsMisspelled(const std::string& word) {
   bool result;
 
   @autoreleasepool {
@@ -23,7 +23,7 @@ bool IsMisspelled(const std::string& word) {
   return result;
 }
 
-std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word) {
+std::vector<std::string> MacSpellchecker::GetCorrectionsForMisspelling(const std::string& word) {
   std::vector<std::string> corrections;
 
   @autoreleasepool {

--- a/src/spellchecker_win.cc
+++ b/src/spellchecker_win.cc
@@ -1,0 +1,10 @@
+#include "spellchecker.h"
+#include "spellchecker_hunspell.h"
+
+namespace spellchecker {
+
+SpellcheckerImplementation* SpellcheckerFactory::CreateSpellchecker() {
+  return new HunspellSpellchecker();
+}
+
+}  // namespace spellchecker


### PR DESCRIPTION
node-spellchecker has a number of deficiencies that this PR starts to fix up:

* Dictionary is hard-coded to en_US on Windows
* Dictionaries are hard-coded to the vendor directory, which fails on ASAR because Hunspell can't load it out of an ASAR archive
* These settings are globals, so having >1 language active is impossible (i.e. if you detect the user switched their keyboard layout to Spanish, you couldn't blow away the old Hunspell)

To fix this, this PR introduces a new class:

#### Spellchecker

* `setDictionary(language, dictionaryPath)` - This method must be called before any other method is called, it configures the language (`en_US`) and the path to the dictionary (optional, default is `.`)

* `isMisspelled` - Identical to v1 `isMisspelled` method, returns a `bool` marking whether a word is misspelled

* `getCorrectionsForMisspelling` - Identical to v1 `getCorrectionsForMisspelling` method, returns a list of corrections for a misspelled word.

This PR also maintains compatibility with the v1 API via creating a default `Spellchecker` when the original methods are called