### PR TITLE
Windows 8 Spellchecker + Update Mac Spellchecker

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -49,6 +49,29 @@ class Spellchecker : public ObjectWrap {
     NanReturnValue(NanNew<Boolean>(that->impl->IsMisspelled(word)));
   }
 
+  static NAN_METHOD(GetAvailableDictionaries) {
+    NanScope();
+
+    Spellchecker* that = ObjectWrap::Unwrap<Spellchecker>(args.Holder());
+
+    std::string path = ".";
+    if (args.Length() > 0) {
+      std::string path = *String::Utf8Value(args[0]);
+    }
+
+    std::vector<std::string> dictionaries =
+      that->impl->GetAvailableDictionaries(path);
+
+    Local<Array> result = NanNew<Array>(dictionaries.size());
+    for (size_t i = 0; i < dictionaries.size(); ++i) {
+      const std::string& dict = dictionaries[i];
+      result->Set(i, NanNew<String>(dict.data(), dict.size()));
+    }
+
+    NanReturnValue(result);
+  }
+
+
   static NAN_METHOD(GetCorrectionsForMisspelling) {
     NanScope();
     if (args.Length() < 1) {
@@ -87,6 +110,7 @@ class Spellchecker : public ObjectWrap {
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
     NODE_SET_METHOD(tpl->InstanceTemplate(), "setDictionary", Spellchecker::SetDictionary);
+    NODE_SET_METHOD(tpl->InstanceTemplate(), "getAvailableDictionaries", Spellchecker::GetAvailableDictionaries);
     NODE_SET_METHOD(tpl->InstanceTemplate(), "getCorrectionsForMisspelling", Spellchecker::GetCorrectionsForMisspelling);
     NODE_SET_METHOD(tpl->InstanceTemplate(), "isMisspelled", Spellchecker::IsMisspelled);
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -33,8 +33,8 @@ class Spellchecker : public ObjectWrap {
       directory = *String::Utf8Value(args[1]);
     }
 
-    that->impl->SetDictionary(language, directory);
-    NanReturnUndefined();
+    bool result = that->impl->SetDictionary(language, directory);
+    NanReturnValue(NanNew<Boolean>(result));
   }
 
   static NAN_METHOD(IsMisspelled) {

--- a/src/spellchecker.h
+++ b/src/spellchecker.h
@@ -9,6 +9,7 @@ namespace spellchecker {
 class SpellcheckerImplementation {
 public:
   virtual bool SetDictionary(const std::string& language, const std::string& path) = 0;
+  virtual std::vector<std::string> GetAvailableDictionaries(const std::string& path) = 0;
 
   // Returns an array containing possible corrections for the word.
   virtual std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word) = 0;

--- a/src/spellchecker.h
+++ b/src/spellchecker.h
@@ -8,7 +8,7 @@ namespace spellchecker {
 
 class SpellcheckerImplementation {
 public:
-  virtual void SetDictionary(const std::string& language, const std::string& path) = 0;
+  virtual bool SetDictionary(const std::string& language, const std::string& path) = 0;
 
   // Returns an array containing possible corrections for the word.
   virtual std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word) = 0;

--- a/src/spellchecker_hunspell.cc
+++ b/src/spellchecker_hunspell.cc
@@ -23,6 +23,7 @@ bool HunspellSpellchecker::SetDictionary(const std::string& language, const std:
   std::string affixpath = dirname + "/" + language + ".aff";
   std::string dpath = dirname + "/" + language + ".dic";
 
+  // TODO: This code is almost certainly jacked on Win32 for non-ASCII paths
   FILE* handle = fopen(dpath.c_str(), "r");
   if (!handle) {
     return false;
@@ -31,6 +32,10 @@ bool HunspellSpellchecker::SetDictionary(const std::string& language, const std:
   fclose(handle);
   this->hunspell = new Hunspell(affixpath.c_str(), dpath.c_str());
   return true;
+}
+
+std::vector<std::string> HunspellSpellchecker::GetAvailableDictionaries(const std::string& path) {
+  return std::vector<std::string>();
 }
 
 bool HunspellSpellchecker::IsMisspelled(const std::string& word) {

--- a/src/spellchecker_hunspell.cc
+++ b/src/spellchecker_hunspell.cc
@@ -1,5 +1,5 @@
+#include <cstdio>
 #include "../vendor/hunspell/src/hunspell/hunspell.hxx"
-
 #include "spellchecker_hunspell.h"
 
 namespace spellchecker {
@@ -14,14 +14,23 @@ HunspellSpellchecker::~HunspellSpellchecker() {
   delete this->hunspell;
 }
 
-void HunspellSpellchecker::SetDictionary(const std::string& language, const std::string& dirname) {
+bool HunspellSpellchecker::SetDictionary(const std::string& language, const std::string& dirname) {
   if (hunspell != NULL) {
     delete this->hunspell;
+    hunspell = NULL;
   }
 
   std::string affixpath = dirname + "/" + language + ".aff";
   std::string dpath = dirname + "/" + language + ".dic";
+
+  FILE* handle = fopen(dpath.c_str(), "r");
+  if (!handle) {
+    return false;
+  }
+
+  fclose(handle);
   this->hunspell = new Hunspell(affixpath.c_str(), dpath.c_str());
+  return true;
 }
 
 bool HunspellSpellchecker::IsMisspelled(const std::string& word) {

--- a/src/spellchecker_hunspell.h
+++ b/src/spellchecker_hunspell.h
@@ -13,6 +13,7 @@ public:
   ~HunspellSpellchecker();
 
   bool SetDictionary(const std::string& language, const std::string& path);
+  std::vector<std::string> GetAvailableDictionaries(const std::string& path);
   std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
   bool IsMisspelled(const std::string& word);
 

--- a/src/spellchecker_hunspell.h
+++ b/src/spellchecker_hunspell.h
@@ -12,7 +12,7 @@ public:
   HunspellSpellchecker();
   ~HunspellSpellchecker();
 
-  void SetDictionary(const std::string& language, const std::string& path);
+  bool SetDictionary(const std::string& language, const std::string& path);
   std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
   bool IsMisspelled(const std::string& word);
 

--- a/src/spellchecker_mac.h
+++ b/src/spellchecker_mac.h
@@ -7,7 +7,7 @@ namespace spellchecker {
 
 class MacSpellchecker : public SpellcheckerImplementation {
 public:
-  void SetDictionary(const std::string& language, const std::string& path);
+  bool SetDictionary(const std::string& language, const std::string& path);
   std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
   bool IsMisspelled(const std::string& word);
 };

--- a/src/spellchecker_mac.h
+++ b/src/spellchecker_mac.h
@@ -3,13 +3,23 @@
 
 #include "spellchecker.h"
 
+#import <Cocoa/Cocoa.h>
+#import <dispatch/dispatch.h>
+
 namespace spellchecker {
 
 class MacSpellchecker : public SpellcheckerImplementation {
 public:
+  MacSpellchecker();
+  ~MacSpellchecker();
+
   bool SetDictionary(const std::string& language, const std::string& path);
+  std::vector<std::string> GetAvailableDictionaries(const std::string& path);
   std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
   bool IsMisspelled(const std::string& word);
+
+private:
+  NSSpellChecker* spellChecker;
 };
 
 }  // namespace spellchecker

--- a/src/spellchecker_mac.mm
+++ b/src/spellchecker_mac.mm
@@ -5,7 +5,8 @@
 
 namespace spellchecker {
 
-void MacSpellchecker::SetDictionary(const std::string& language, const std::string& path) {
+bool MacSpellchecker::SetDictionary(const std::string& language, const std::string& path) {
+  return true;
 }
 
 bool MacSpellchecker::IsMisspelled(const std::string& word) {

--- a/src/spellchecker_mac.mm
+++ b/src/spellchecker_mac.mm
@@ -5,8 +5,36 @@
 
 namespace spellchecker {
 
+
+MacSpellchecker::MacSpellchecker() {
+  this->spellChecker = [[NSSpellChecker alloc] init];
+  [this->spellChecker setAutomaticallyIdentifiesLanguages: NO];
+}
+
+MacSpellchecker::~MacSpellchecker() {
+  [this->spellChecker release];
+}
+
+
 bool MacSpellchecker::SetDictionary(const std::string& language, const std::string& path) {
-  return true;
+  @autoreleasepool {
+    NSString* lang = [NSString stringWithUTF8String: language.c_str()];
+    return [this->spellChecker setLanguage: lang] == YES;
+  }
+}
+
+std::vector<std::string> MacSpellchecker::GetAvailableDictionaries(const std::string& path) {
+  std::vector<std::string> ret;
+
+  @autoreleasepool {
+    NSArray* languages = [this->spellChecker availableLanguages];
+
+    for (size_t i = 0; i < languages.count; ++i) {
+      ret.push_back([[languages objectAtIndex:i] UTF8String]);
+    }
+  }
+
+  return ret;
 }
 
 bool MacSpellchecker::IsMisspelled(const std::string& word) {
@@ -14,13 +42,12 @@ bool MacSpellchecker::IsMisspelled(const std::string& word) {
 
   @autoreleasepool {
     NSString* misspelling = [NSString stringWithUTF8String:word.c_str()];
-    NSSpellChecker* spellChecker = [NSSpellChecker sharedSpellChecker];
-    @synchronized(spellChecker) {
-      NSRange range = [spellChecker checkSpellingOfString:misspelling
-                                               startingAt:0];
-      result = range.length > 0;
-    }
+    NSRange range = [this->spellChecker checkSpellingOfString:misspelling
+                                                   startingAt:0];
+
+    result = range.length > 0;
   }
+
   return result;
 }
 
@@ -29,22 +56,24 @@ std::vector<std::string> MacSpellchecker::GetCorrectionsForMisspelling(const std
 
   @autoreleasepool {
     NSString* misspelling = [NSString stringWithUTF8String:word.c_str()];
-    NSSpellChecker* spellChecker = [NSSpellChecker sharedSpellChecker];
-    @synchronized(spellChecker) {
-      NSString* language = [spellChecker language];
-      NSRange range;
-      range.location = 0;
-      range.length = [misspelling length];
-      NSArray* guesses = [spellChecker guessesForWordRange:range
-                                                  inString:misspelling
-                                                  language:language
-                                    inSpellDocumentWithTag:0];
+    NSString* language = [this->spellChecker language];
+    NSRange range;
 
-      corrections.reserve(guesses.count);
-      for (size_t i = 0; i < guesses.count; ++i)
-        corrections.push_back([[guesses objectAtIndex:i] UTF8String]);
+    range.location = 0;
+    range.length = [misspelling length];
+
+    NSArray* guesses = [this->spellChecker guessesForWordRange:range
+                                                      inString:misspelling
+                                                      language:language
+                                        inSpellDocumentWithTag:0];
+
+    corrections.reserve(guesses.count);
+
+    for (size_t i = 0; i < guesses.count; ++i) {
+      corrections.push_back([[guesses objectAtIndex:i] UTF8String]);
     }
   }
+
   return corrections;
 }
 

--- a/src/spellchecker_win.cc
+++ b/src/spellchecker_win.cc
@@ -1,10 +1,30 @@
 #include "spellchecker.h"
+#include "spellchecker_win.h"
 #include "spellchecker_hunspell.h"
 
 namespace spellchecker {
 
+bool WindowsSpellchecker::IsSupported() {
+  return false;
+}
+
+void WindowsSpellchecker::SetDictionary(const std::string& language, const std::string& path) {
+}
+
+bool WindowsSpellchecker::IsMisspelled(const std::string& word) {
+  return false;
+}
+
+std::vector<std::string> WindowsSpellchecker::GetCorrectionsForMisspelling(const std::string& word) {
+  return std::vector<std::string>();
+}
+
 SpellcheckerImplementation* SpellcheckerFactory::CreateSpellchecker() {
-  return new HunspellSpellchecker();
+  if (WindowsSpellchecker::IsSupported()) {
+    return new WindowsSpellchecker();
+  } else {
+    return new HunspellSpellchecker();
+  }
 }
 
 }  // namespace spellchecker

--- a/src/spellchecker_win.cc
+++ b/src/spellchecker_win.cc
@@ -87,6 +87,10 @@ bool WindowsSpellchecker::IsSupported() {
 bool WindowsSpellchecker::SetDictionary(const std::string& language, const std::string& path) {
   HRESULT hr;
 
+  if (!this->spellcheckerFactory) {
+    return false;
+  }
+
   if (this->currentSpellchecker != NULL) {
     this->currentSpellchecker->Release();
     this->currentSpellchecker = NULL;

--- a/src/spellchecker_win.cc
+++ b/src/spellchecker_win.cc
@@ -1,9 +1,17 @@
 #include <windows.h>
+#include <guiddef.h>
+#include <initguid.h>
+#include <string>
 #include <spellcheck.h>
 
 #include "spellchecker.h"
 #include "spellchecker_win.h"
 #include "spellchecker_hunspell.h"
+
+// NB: No idea why I have to define this myself, you don't have to in a
+// standard console app.
+DEFINE_GUID(CLSID_SpellCheckerFactory,0x7AB36653,0x1796,0x484B,0xBD,0xFA,0xE7,0x4F,0x1D,0xB7,0xC1,0xDC);
+DEFINE_GUID(IID_ISpellCheckerFactory,0x8E018A9D,0x2415,0x4677,0xBF,0x08,0x79,0x4E,0xA6,0x1F,0x94,0xBB);
 
 namespace spellchecker {
 

--- a/src/spellchecker_win.cc
+++ b/src/spellchecker_win.cc
@@ -1,4 +1,5 @@
 #include <windows.h>
+#include <spellcheck.h>
 
 #include "spellchecker.h"
 #include "spellchecker_win.h"
@@ -9,32 +10,163 @@ namespace spellchecker {
 LONG g_COMRefcount = 0;
 bool g_COMFailed = false;
 
+std::string ToUTF8(const std::wstring& string) {
+  if (string.length() < 1) {
+    return std::string();
+  }
+
+  // NB: In the pathological case, each character could expand up
+  // to 4 bytes in UTF8.
+  int cbLen = (string.length()+1) * sizeof(char) * 4;
+  char* buf = new char[cbLen];
+  WideCharToMultiByte(CP_UTF8, 0, string.c_str(), string.length(), buf, cbLen, NULL, NULL);
+
+  std::string ret;
+  ret.assign(buf);
+  return ret;
+}
+
+std::wstring ToWString(const std::string& string) {
+  if (string.length() < 1) {
+    return std::wstring();
+  }
+
+  // NB: If you got really unlucky, every character could be a two-wchar_t
+  // surrogate pair
+  int cchLen = (string.length()+1) * 2;
+  wchar_t* buf = new wchar_t[cchLen];
+  MultiByteToWideChar(CP_UTF8, 0, string.c_str(), strlen(string.c_str()), buf, cchLen);
+
+  std::wstring ret;
+  ret.assign(buf);
+  return ret;
+}
+
 WindowsSpellchecker::WindowsSpellchecker() {
+  this->currentSpellchecker = NULL;
+
   if (InterlockedIncrement(&g_COMRefcount) == 1) {
     g_COMFailed = FAILED(CoInitialize(NULL));
+    return;
+  }
+
+  // NB: This will fail on < Win8
+  HRESULT hr = CoCreateInstance(
+    CLSID_SpellCheckerFactory, NULL, CLSCTX_INPROC_SERVER, IID_ISpellCheckerFactory,
+    reinterpret_cast<PVOID*>(&this->spellcheckerFactory));
+
+  if (FAILED(hr)) {
+    this->spellcheckerFactory = NULL;
   }
 }
 
 WindowsSpellchecker::~WindowsSpellchecker() {
+  if (this->spellcheckerFactory) {
+    this->spellcheckerFactory->Release();
+  }
+
   if (InterlockedDecrement(&g_COMRefcount) == 0) {
     CoUninitialize();
   }
 }
 
 bool WindowsSpellchecker::IsSupported() {
-  return g_COMFailed && false;
+  return !(g_COMFailed || (spellcheckerFactory == NULL));
 }
 
 bool WindowsSpellchecker::SetDictionary(const std::string& language, const std::string& path) {
-  return false;
+  if (this->currentSpellchecker != NULL) {
+    this->currentSpellchecker->Release();
+    this->currentSpellchecker = NULL;
+  }
+
+  // Figure out if we have a dictionary installed for the language they want
+  std::wstring wlanguage = ToWString(language);
+  BOOL isSupported;
+
+  if (FAILED(this->spellcheckerFactory->IsSupported(wlanguage.c_str(), &isSupported))) {
+    return false;
+  }
+
+  if (!isSupported) return false;
+
+  if (FAILED(this->spellcheckerFactory->CreateSpellChecker(wlanguage.c_str(), &this->currentSpellchecker))) {
+    return false;
+  }
+
+  return true;
 }
 
 bool WindowsSpellchecker::IsMisspelled(const std::string& word) {
-  return false;
+  if (this->currentSpellchecker == NULL) {
+    return false;
+  }
+
+  IEnumSpellingError* errors = NULL;
+  std::wstring wword = ToWString(word);
+  if (FAILED(this->currentSpellchecker->Check(wword.c_str(), &errors))) {
+    return false;
+  }
+
+  bool ret;
+
+  ISpellingError* dontcare;
+  HRESULT hr = errors->Next(&dontcare);
+
+  switch (hr) {
+  case S_OK:
+    // S_OK == There are errors to examine
+    ret = true;
+    dontcare->Release();
+    break;
+  case S_FALSE:
+    // Worked, but error free
+    ret = false;
+    break;
+  default:
+    // Something went pear-shaped
+    ret = false;
+    break;
+  }
+
+  errors->Release();
+  return ret;
 }
 
 std::vector<std::string> WindowsSpellchecker::GetCorrectionsForMisspelling(const std::string& word) {
-  return std::vector<std::string>();
+  if (this->currentSpellchecker == NULL) {
+    return std::vector<std::string>();
+  }
+
+  std::wstring& wword = ToWString(word);
+  IEnumString* words = NULL;
+
+  HRESULT hr = this->currentSpellchecker->Suggest(wword.c_str(), &words);
+
+  if (FAILED(hr)) {
+    return std::vector<std::string>();
+  }
+
+  // NB: S_FALSE == word is spelled correctly
+  if (hr == S_FALSE) {
+    words->Release();
+    return std::vector<std::string>();
+  }
+
+  std::vector<std::string> ret;
+
+  LPOLESTR correction;
+  ULONG dontcare;
+  while (words->Next(1, &correction, &dontcare)) {
+    std::wstring wcorr;
+    wcorr.assign(correction);
+    ret.push_back(ToUTF8(wcorr));
+
+    CoTaskMemFree(correction);
+  }
+
+  words->Release();
+  return ret;
 }
 
 SpellcheckerImplementation* SpellcheckerFactory::CreateSpellchecker() {

--- a/src/spellchecker_win.cc
+++ b/src/spellchecker_win.cc
@@ -25,7 +25,8 @@ bool WindowsSpellchecker::IsSupported() {
   return g_COMFailed && false;
 }
 
-void WindowsSpellchecker::SetDictionary(const std::string& language, const std::string& path) {
+bool WindowsSpellchecker::SetDictionary(const std::string& language, const std::string& path) {
+  return false;
 }
 
 bool WindowsSpellchecker::IsMisspelled(const std::string& word) {

--- a/src/spellchecker_win.cc
+++ b/src/spellchecker_win.cc
@@ -109,6 +109,33 @@ bool WindowsSpellchecker::SetDictionary(const std::string& language, const std::
   return true;
 }
 
+std::vector<std::string> WindowsSpellchecker::GetAvailableDictionaries(const std::string& path) {
+  HRESULT hr;
+
+  if (!this->spellcheckerFactory) {
+    return std::vector<std::string>();
+  }
+
+  IEnumString* langList;
+  if (FAILED(hr = this->spellcheckerFactory->get_SupportedLanguages(&langList))) {
+    return std::vector<std::string>();
+  }
+
+  std::vector<std::string> ret;
+  LPOLESTR str;
+  while (langList->Next(1, &str, NULL) == S_OK) {
+    std::wstring wlang;
+    wlang.assign(str);
+    ret.push_back(ToUTF8(wlang));
+
+    CoTaskMemFree(str);
+  }
+
+  langList->Release();
+  return ret;
+}
+
+
 bool WindowsSpellchecker::IsMisspelled(const std::string& word) {
   if (this->currentSpellchecker == NULL) {
     return false;

--- a/src/spellchecker_win.h
+++ b/src/spellchecker_win.h
@@ -1,6 +1,7 @@
 #ifndef SRC_SPELLCHECKER_WIN_H_
 #define SRC_SPELLCHECKER_WIN_H_
 
+#include <spellcheck.h>
 #include "spellchecker.h"
 
 namespace spellchecker {
@@ -12,7 +13,7 @@ public:
   WindowsSpellchecker();
   ~WindowsSpellchecker();
 
-  void SetDictionary(const std::string& language, const std::string& path);
+  bool SetDictionary(const std::string& language, const std::string& path);
   std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
   bool IsMisspelled(const std::string& word);
 };

--- a/src/spellchecker_win.h
+++ b/src/spellchecker_win.h
@@ -16,6 +16,10 @@ public:
   bool SetDictionary(const std::string& language, const std::string& path);
   std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
   bool IsMisspelled(const std::string& word);
+
+private:
+  ISpellChecker* currentSpellchecker;
+  ISpellCheckerFactory* spellcheckerFactory;
 };
 
 }  // namespace spellchecker

--- a/src/spellchecker_win.h
+++ b/src/spellchecker_win.h
@@ -1,0 +1,19 @@
+#ifndef SRC_SPELLCHECKER_WIN_H_
+#define SRC_SPELLCHECKER_WIN_H_
+
+#include "spellchecker.h"
+
+namespace spellchecker {
+
+class WindowsSpellchecker : public SpellcheckerImplementation {
+public:
+  static bool IsSupported();
+
+  void SetDictionary(const std::string& language, const std::string& path);
+  std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
+  bool IsMisspelled(const std::string& word);
+};
+
+}  // namespace spellchecker
+
+#endif  // SRC_SPELLCHECKER_MAC_H_

--- a/src/spellchecker_win.h
+++ b/src/spellchecker_win.h
@@ -14,6 +14,8 @@ public:
   ~WindowsSpellchecker();
 
   bool SetDictionary(const std::string& language, const std::string& path);
+  std::vector<std::string> GetAvailableDictionaries(const std::string& path);
+
   std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
   bool IsMisspelled(const std::string& word);
 

--- a/src/spellchecker_win.h
+++ b/src/spellchecker_win.h
@@ -7,7 +7,10 @@ namespace spellchecker {
 
 class WindowsSpellchecker : public SpellcheckerImplementation {
 public:
-  static bool IsSupported();
+  bool IsSupported();
+
+  WindowsSpellchecker();
+  ~WindowsSpellchecker();
 
   void SetDictionary(const std::string& language, const std::string& path);
   std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);


### PR DESCRIPTION
This PR implements a new spellchecker for >= Windows 8 based on the `ISpellchecker` API. This method also adds a new method to `Spellchecker`

* `getAvailableDictionaries()` - Returns the list of dictionaries available as an array of strings

On Windows, if `ISpellchecker` isn't available (i.e. they're running Win7), we'll automatically fall back to Hunspell

This PR also updates the OS X spellchecker to support these methods