### PR TITLE
Removes the deprecated call to NanSymbol

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -83,7 +83,7 @@ class Spellchecker : public ObjectWrap {
   static void Init(Handle<Object> exports) {
     Local<FunctionTemplate> tpl = NanNew<FunctionTemplate>(Spellchecker::New);
 
-    tpl->SetClassName(NanSymbol("Spellchecker"));
+    tpl->SetClassName(NanNew<String>("Spellchecker"));
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
     NODE_SET_METHOD(tpl->InstanceTemplate(), "setDictionary", Spellchecker::SetDictionary);


### PR DESCRIPTION
When building node-spellchecker as a native module it gives a deprecation warning on the use of `NanSymbol` that has been replaced with `NanNew<String>` [since version 1.1.0 of **nan**](https://github.com/rvagg/nan/blob/master/CHANGELOG.md#110-may-25-2014)