### PR TITLE
Allow non-us-english languages, respect system language default, test cleanup

### DIFF
--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -5,6 +5,17 @@ var Spellchecker = bindings.Spellchecker;
 
 var defaultSpellcheck = null;
 
+var ensureDefaultSpellCheck = function() {
+  if (defaultSpellcheck) {
+    return;
+  }
+  defaultSpellcheck = new Spellchecker();
+};
+
+var setLanguage = function(lang) {
+  setDictionary(lang, getDictionaryPath());
+};
+
 var setDictionary = function(lang, dictPath) {
   // NB: Windows 8 uses *dashes* to set the language (i.e. en-US), so if we fail
   // to set the language, try the Windows 8 way
@@ -15,17 +26,18 @@ var setDictionary = function(lang, dictPath) {
   }
 };
 
-var ensureDefaultSpellCheck = function() {
-  if (defaultSpellcheck) {
-    return;
+var getDictionaryPath = function() {
+  var dict = path.join(__dirname, '..', 'vendor', 'hunspell_dictionaries');
+  try {
+    // HACK: Special case being in an asar archive
+    var unpacked = dict.replace('.asar' + path.sep, '.asar.unpacked' + path.sep);
+    if (require('fs').statSyncNoException(unpacked)) {
+      dict = unpacked;
+    }
+  } catch (error) {
   }
-  defaultSpellcheck = new Spellchecker();
-  setDictionary('en_US', getDictionaryPath());
-};
-
-var setLanguage = function(lang) {
-  setDictionary(lang, getDictionaryPath())
-};
+  return dict;
+}
 
 var isMisspelled = function() {
   ensureDefaultSpellCheck();
@@ -46,23 +58,8 @@ var getCorrectionsForMisspelling = function() {
 };
 
 var getAvailableDictionaries = function() {
-  ensureDefaultSpellCheck();
-
   return defaultSpellcheck.getAvailableDictionaries.apply(defaultSpellcheck, arguments);
 };
-
-var getDictionaryPath = function() {
-  var dict = path.join(__dirname, '..', 'vendor', 'hunspell_dictionaries');
-  try {
-    // HACK: Special case being in an asar archive
-    var unpacked = dict.replace('.asar' + path.sep, '.asar.unpacked' + path.sep);
-    if (require('fs').statSyncNoException(unpacked)) {
-      dict = unpacked;
-    }
-  } catch (error) {
-  }
-  return dict;
-}
 
 module.exports = {
   setDictionary: setDictionary,

--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -13,6 +13,7 @@ var ensureDefaultSpellCheck = function() {
 };
 
 var setLanguage = function(lang) {
+  ensureDefaultSpellCheck();
   setDictionary(lang, getDictionaryPath());
 };
 
@@ -58,8 +59,15 @@ var getCorrectionsForMisspelling = function() {
 };
 
 var getAvailableDictionaries = function() {
+  ensureDefaultSpellCheck();
+
   return defaultSpellcheck.getAvailableDictionaries.apply(defaultSpellcheck, arguments);
 };
+
+var getDefaultLanguage = function() {
+  ensureDefaultSpellCheck();
+  return getAvailableDictionaries()[0];
+}
 
 module.exports = {
   setDictionary: setDictionary,
@@ -68,5 +76,7 @@ module.exports = {
   isMisspelled: isMisspelled,
   getAvailableDictionaries: getAvailableDictionaries,
   getCorrectionsForMisspelling: getCorrectionsForMisspelling,
-  Spellchecker: Spellchecker
+  Spellchecker: Spellchecker,
+  getDefaultLanguage: getDefaultLanguage
+
 };

--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -23,6 +23,10 @@ var ensureDefaultSpellCheck = function() {
   setDictionary('en_US', getDictionaryPath());
 };
 
+var setLanguage = function(lang) {
+  setDictionary(lang, getDictionaryPath())
+};
+
 var isMisspelled = function() {
   ensureDefaultSpellCheck();
 
@@ -62,6 +66,7 @@ var getDictionaryPath = function() {
 
 module.exports = {
   setDictionary: setDictionary,
+  setLanguage: setLanguage,
   add: add,
   isMisspelled: isMisspelled,
   getAvailableDictionaries: getAvailableDictionaries,

--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -6,7 +6,6 @@ var Spellchecker = bindings.Spellchecker;
 var defaultSpellcheck = null;
 
 var setDictionary = function(lang, dictPath) {
-  defaultSpellcheck = new Spellchecker();
   // NB: Windows 8 uses *dashes* to set the language (i.e. en-US), so if we fail
   // to set the language, try the Windows 8 way
   lang = lang.replace('_', '-');
@@ -20,6 +19,7 @@ var ensureDefaultSpellCheck = function() {
   if (defaultSpellcheck) {
     return;
   }
+  defaultSpellcheck = new Spellchecker();
   setDictionary('en_US', getDictionaryPath());
 };
 

--- a/spec/spellchecker-spec.coffee
+++ b/spec/spellchecker-spec.coffee
@@ -20,11 +20,6 @@ describe "SpellChecker", ->
     it "throws an exception when no word specified", ->
       expect(-> SpellChecker.getCorrectionsForMisspelling()).toThrow()
 
-  describe ".add(word)", ->
-    it "allows words to be added to the dictionary", ->
-      expect(SpellChecker.isMisspelled('wwoorrdd')).toBe true
-      SpellChecker.add('wwoorrdd')
-      expect(SpellChecker.isMisspelled('wwoorrdd')).toBe false
 
     it "throws an error if no word is specified", ->
       errorOccurred = false

--- a/spec/spellchecker-spec.coffee
+++ b/spec/spellchecker-spec.coffee
@@ -36,7 +36,6 @@ describe "SpellChecker", ->
     it "throws an exception when no word specified", ->
       expect(-> SpellChecker.getCorrectionsForMisspelling()).toThrow()
 
-
     it "throws an error if no word is specified", ->
       errorOccurred = false
       try

--- a/spec/spellchecker-spec.coffee
+++ b/spec/spellchecker-spec.coffee
@@ -42,10 +42,6 @@ describe "SpellChecker", ->
         expect(typeof dictionary).toBe 'string'
         expect(diction.length).toBeGreaterThan 0
 
-  describe ".setDictionary(lang, dictDirectory)", ->
-    it "sets the spell checker's language, and dictionary directory", ->
-      awesome = true
-      expect(awesome).toBe true
   describe ".setLanguage(lang, dictDirectory)", ->
     it "sets the spell checker's language", ->
       SpellChecker.setLanguage('de')

--- a/spec/spellchecker-spec.coffee
+++ b/spec/spellchecker-spec.coffee
@@ -3,9 +3,11 @@ SpellChecker = require '../lib/spellchecker'
 describe "SpellChecker", ->
   describe ".isMisspelled(word)", ->
     it "returns true if the word is mispelled", ->
+      SpellChecker.setLanguage('en_us') # Override the system default.
       expect(SpellChecker.isMisspelled('wwoorrdd')).toBe true
 
     it "returns false if the word isn't mispelled", ->
+      SpellChecker.setLanguage('en_us')
       expect(SpellChecker.isMisspelled('word')).toBe false
 
     it "throws an exception when no word specified", ->
@@ -13,6 +15,7 @@ describe "SpellChecker", ->
 
   describe ".getCorrectionsForMisspelling(word)", ->
     it "returns an array of possible corrections", ->
+      SpellChecker.setLanguage('en_us')
       corrections = SpellChecker.getCorrectionsForMisspelling('worrd')
       expect(corrections.length).toBeGreaterThan 0
       expect(corrections.indexOf('word')).toBeGreaterThan -1

--- a/spec/spellchecker-spec.coffee
+++ b/spec/spellchecker-spec.coffee
@@ -1,13 +1,26 @@
 SpellChecker = require '../lib/spellchecker'
 
 describe "SpellChecker", ->
+
+  describe "getDefaultLanguage()", ->
+    it "uses the system default dictionary", ->
+      systemDefaultLanguage = SpellChecker.getDefaultLanguage()
+      systemDefaultLanguage = systemDefaultLanguage.toLowerCase().replace('-', '_')
+      switch systemDefaultLanguage
+        when "en_gb", "en_uk"
+          expect(SpellChecker.isMisspelled('colour')).toBe false;
+          expect(SpellChecker.isMisspelled('color')).toBe true;
+        when "en", "en_us"
+          expect(SpellChecker.isMisspelled('colour')).toBe true;
+          expect(SpellChecker.isMisspelled('color')).toBe false;
+
   describe ".isMisspelled(word)", ->
     it "returns true if the word is mispelled", ->
-      SpellChecker.setLanguage('en_us') # Override the system default.
+      SpellChecker.setLanguage('en') # Override the system default.
       expect(SpellChecker.isMisspelled('wwoorrdd')).toBe true
 
     it "returns false if the word isn't mispelled", ->
-      SpellChecker.setLanguage('en_us')
+      SpellChecker.setLanguage('en')
       expect(SpellChecker.isMisspelled('word')).toBe false
 
     it "throws an exception when no word specified", ->
@@ -15,7 +28,7 @@ describe "SpellChecker", ->
 
   describe ".getCorrectionsForMisspelling(word)", ->
     it "returns an array of possible corrections", ->
-      SpellChecker.setLanguage('en_us')
+      SpellChecker.setLanguage('en')
       corrections = SpellChecker.getCorrectionsForMisspelling('worrd')
       expect(corrections.length).toBeGreaterThan 0
       expect(corrections.indexOf('word')).toBeGreaterThan -1

--- a/spec/spellchecker-spec.coffee
+++ b/spec/spellchecker-spec.coffee
@@ -51,3 +51,16 @@ describe "SpellChecker", ->
     it "sets the spell checker's language, and dictionary directory", ->
       awesome = true
       expect(awesome).toBe true
+  describe ".setLanguage(lang, dictDirectory)", ->
+    it "sets the spell checker's language", ->
+      SpellChecker.setLanguage('de')
+      expect(SpellChecker.isMisspelled('Wortwitz')).toBe false
+      expect(SpellChecker.isMisspelled('Wortwitzz')).toBe true
+      expect(SpellChecker.isMisspelled('Schnabeltier')).toBe false
+      expect(SpellChecker.isMisspelled('Platypus')).toBe true
+      SpellChecker.setLanguage('en_uk')
+      expect(SpellChecker.isMisspelled('colour')).toBe false
+      expect(SpellChecker.isMisspelled('color')).toBe true
+      SpellChecker.setLanguage('en_us')
+      expect(SpellChecker.isMisspelled('color')).toBe false
+      expect(SpellChecker.isMisspelled('colour')).toBe true


### PR DESCRIPTION
Modifications here were tested on Mac; I don't have another platform on which to test.

Problems addressed: 
https://github.com/atom/node-spellchecker/issues/15 -- by removing the hard-coded setting of the default language. 
Cleaned up spec file to remove the redundant test of the setDictionary
Added a more user friendly setLanguage() which calls setDictionary() but doesn't require any knowledge of the dictionary path (could be useful for solving https://github.com/atom/spell-check/issues/21); also allows more robust testing of behaviour on platforms with non-english default languages.
Rearranged spellchecker file so that functions can be read in order from top to bottom.

Testing required:
Do other platforms have the same behaviour on instantiation of the spellchecker -- namely they set a language default based on the system? 
