### PR TITLE
Protect against crash in destructor on Win7

### DIFF
--- a/src/spellchecker_win.cc
+++ b/src/spellchecker_win.cc
@@ -55,6 +55,7 @@ std::wstring ToWString(const std::string& string) {
 }
 
 WindowsSpellchecker::WindowsSpellchecker() {
+  this->spellcheckerFactory = NULL;
   this->currentSpellchecker = NULL;
 
   if (InterlockedIncrement(&g_COMRefcount) == 1) {
@@ -73,8 +74,14 @@ WindowsSpellchecker::WindowsSpellchecker() {
 }
 
 WindowsSpellchecker::~WindowsSpellchecker() {
+  if (this->currentSpellchecker) {
+    this->currentSpellchecker->Release();
+    this->currentSpellchecker = NULL;
+  }
+  
   if (this->spellcheckerFactory) {
     this->spellcheckerFactory->Release();
+    this->spellcheckerFactory = NULL;
   }
 
   if (InterlockedDecrement(&g_COMRefcount) == 0) {
@@ -83,7 +90,7 @@ WindowsSpellchecker::~WindowsSpellchecker() {
 }
 
 bool WindowsSpellchecker::IsSupported() {
-  return !(g_COMFailed || (spellcheckerFactory == NULL));
+  return !(g_COMFailed || (this->spellcheckerFactory == NULL));
 }
 
 bool WindowsSpellchecker::SetDictionary(const std::string& language, const std::string& path) {


### PR DESCRIPTION
I thoroughly do not know how this is possible, but we're seeing a repeatable crash on Win7 machines in the WindowsSpellchecker destructor:

```
0:000> k
 # ChildEBP RetAddr  
00 002edce8 714b3f1d spellchecker!spellchecker::WindowsSpellchecker::`scalar deleting destructor'+0x10
01 002edcf4 714b145f spellchecker!spellchecker::SpellcheckerFactory::CreateSpellchecker+0x4d [c:\users\paulb\code\tinyspeck\slack-winssb\node_modules\spellchecker\src\spellchecker_win.cc @ 234]
02 002edd0c 714b108a spellchecker!`anonymous namespace'::Spellchecker::New+0x3f [c:\users\paulb\code\tinyspeck\slack-winssb\node_modules\spellchecker\src\main.cc @ 15]
03 002edd2c 70d4f9be spellchecker!Nan::imp::FunctionCallbackWrapper+0x8a [c:\users\paulb\code\tinyspeck\slack-winssb\node_modules\nan\nan_callbacks_12_inl.h @ 174]
04 002edd60 70d3dee9 node!v8::internal::FunctionCallbackArguments::Call+0x7e [y:\jenkins\workspace\libchromiumcontent-win\vendor\chromium\src\v8\src\arguments.cc @ 34]
05 002eddd4 70d3ff1d node!v8::internal::HandleApiCallHelper<1>+0x259 [y:\jenkins\workspace\libchromiumcontent-win\vendor\chromium\src\v8\src\builtins.cc @ 1094]
06 002eddf8 1a70d0fc node!v8::internal::Builtin_implHandleApiCallConstruct+0x2d [y:\jenkins\workspace\libchromiumcontent-win\vendor\chromium\src\v8\src\builtins.cc @ 1126]
WARNING: Frame IP not in any known module. Following frames may be wrong.
07 002ede18 1a72c09c 0x1a70d0fc
```

![](http://cl.ly/image/252f0B1g3Q3d/Lysithea_Remote__2015-11-05_15-05-15.png)