### PR TITLE
Add an API for finding all the misspelled words in a given string

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,10 @@
 environment:
   nodejs_version: "0.10"
 
+  matrix:
+    - {}
+    - {SPELLCHECKER_PREFER_HUNSPELL: true}
+
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm --msvs_version=2013 install

--- a/binding.gyp
+++ b/binding.gyp
@@ -41,17 +41,20 @@
         }],
         ['OS=="win"', {
           'sources': [
-             'src/spellchecker_win.cc'
+             'src/spellchecker_win.cc',
+             'src/transcoder_win.cc',
           ],
         }],
         ['OS=="linux"', {
           'sources': [
-             'src/spellchecker_linux.cc'
+             'src/spellchecker_linux.cc',
+             'src/transcoder_posix.cc',
           ],
         }],
         ['OS=="mac"', {
           'sources': [
             'src/spellchecker_mac.mm',
+            'src/transcoder_posix.cc',
           ],
           'link_settings': {
             'libraries': [

--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -29,6 +29,12 @@ var isMisspelled = function() {
   return defaultSpellcheck.isMisspelled.apply(defaultSpellcheck, arguments);
 };
 
+var checkSpelling = function() {
+  ensureDefaultSpellCheck();
+
+  return defaultSpellcheck.checkSpelling.apply(defaultSpellcheck, arguments);
+};
+
 var add = function() {
   ensureDefaultSpellCheck();
 
@@ -64,6 +70,7 @@ module.exports = {
   setDictionary: setDictionary,
   add: add,
   isMisspelled: isMisspelled,
+  checkSpelling: checkSpelling,
   getAvailableDictionaries: getAvailableDictionaries,
   getCorrectionsForMisspelling: getCorrectionsForMisspelling,
   Spellchecker: Spellchecker

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "./lib/spellchecker.js",
   "name": "spellchecker",
   "description": "Bindings to native spellchecker",
-  "version": "3.1.3",
+  "version": "3.2.0-0",
   "licenses": [
     {
       "type": "MIT",

--- a/spec/spellchecker-spec.coffee
+++ b/spec/spellchecker-spec.coffee
@@ -35,6 +35,12 @@ describe "SpellChecker", ->
         {start: 20, end: 25},
       ]
 
+    it "handles invalid inputs", ->
+      expect(SpellChecker.checkSpelling("")).toEqual []
+      expect(-> SpellChecker.checkSpelling()).toThrow("Bad argument")
+      expect(-> SpellChecker.checkSpelling(null)).toThrow("Bad argument")
+      expect(-> SpellChecker.checkSpelling({})).toThrow("Bad argument")
+
   describe ".getCorrectionsForMisspelling(word)", ->
     it "returns an array of possible corrections", ->
       corrections = SpellChecker.getCorrectionsForMisspelling('worrd')

--- a/spec/spellchecker-spec.coffee
+++ b/spec/spellchecker-spec.coffee
@@ -11,6 +11,15 @@ describe "SpellChecker", ->
     it "throws an exception when no word specified", ->
       expect(-> SpellChecker.isMisspelled()).toThrow()
 
+  describe ".checkSpelling(string)", ->
+    it "returns an array of character ranges of misspelled words", ->
+      string = "cat caat dog dooog"
+
+      expect(SpellChecker.checkSpelling(string)).toEqual [
+        {start: 4, end: 8},
+        {start: 13, end: 18},
+      ]
+
   describe ".getCorrectionsForMisspelling(word)", ->
     it "returns an array of possible corrections", ->
       corrections = SpellChecker.getCorrectionsForMisspelling('worrd')

--- a/spec/spellchecker-spec.coffee
+++ b/spec/spellchecker-spec.coffee
@@ -20,12 +20,19 @@ describe "SpellChecker", ->
         {start: 13, end: 18},
       ]
 
-    it "accounts for UTF16 pairs correctly", ->
+    it "accounts for UTF16 pairs", ->
       string = "😎 cat caat dog dooog"
 
       expect(SpellChecker.checkSpelling(string)).toEqual [
         {start: 7, end: 11},
         {start: 16, end: 21},
+      ]
+
+    it "accounts for other non-word characters", ->
+      string = "'cat' (caat. <dog> :dooog)"
+      expect(SpellChecker.checkSpelling(string)).toEqual [
+        {start: 7, end: 11},
+        {start: 20, end: 25},
       ]
 
   describe ".getCorrectionsForMisspelling(word)", ->

--- a/spec/spellchecker-spec.coffee
+++ b/spec/spellchecker-spec.coffee
@@ -35,6 +35,24 @@ describe "SpellChecker", ->
         {start: 20, end: 25},
       ]
 
+    it "does not treat non-english letters as word boundaries", ->
+      SpellChecker.add("cliché")
+      expect(SpellChecker.checkSpelling("what cliché nonsense")).toEqual []
+
+    it "handles words with apostrophes", ->
+      string = "doesn't isn't aint hasn't"
+      expect(SpellChecker.checkSpelling(string)).toEqual [
+        {start: string.indexOf("aint"), end: string.indexOf("aint") + 4}
+      ]
+
+      string = "you say you're 'certain', but are you really?"
+      expect(SpellChecker.checkSpelling(string)).toEqual []
+
+      string = "you say you're 'sertan', but are you really?"
+      expect(SpellChecker.checkSpelling(string)).toEqual [
+        {start: string.indexOf("sertan"), end: string.indexOf("',")}
+      ]
+
     it "handles invalid inputs", ->
       expect(SpellChecker.checkSpelling("")).toEqual []
       expect(-> SpellChecker.checkSpelling()).toThrow("Bad argument")

--- a/spec/spellchecker-spec.coffee
+++ b/spec/spellchecker-spec.coffee
@@ -20,6 +20,14 @@ describe "SpellChecker", ->
         {start: 13, end: 18},
       ]
 
+    it "accounts for UTF16 pairs correctly", ->
+      string = "😎 cat caat dog dooog"
+
+      expect(SpellChecker.checkSpelling(string)).toEqual [
+        {start: 7, end: 11},
+        {start: 16, end: 21},
+      ]
+
   describe ".getCorrectionsForMisspelling(word)", ->
     it "returns an array of possible corrections", ->
       corrections = SpellChecker.getCorrectionsForMisspelling('worrd')

--- a/src/main.cc
+++ b/src/main.cc
@@ -66,10 +66,13 @@ class Spellchecker : public Nan::ObjectWrap {
     Local<Array> result = Nan::New<Array>();
     std::vector<MisspelledRange>::const_iterator iter = misspelled_ranges.begin();
     for (; iter != misspelled_ranges.end(); ++iter) {
+      size_t index = iter - misspelled_ranges.begin();
+      uint32_t start = iter->start, end = iter->end;
+
       Local<Object> misspelled_range = Nan::New<Object>();
-      misspelled_range->Set(Nan::New("start").ToLocalChecked(), Nan::New<Number>(iter->start));
-      misspelled_range->Set(Nan::New("end").ToLocalChecked(), Nan::New<Number>(iter->end));
-      result->Set(iter - misspelled_ranges.begin(), misspelled_range);
+      misspelled_range->Set(Nan::New("start").ToLocalChecked(), Nan::New<Integer>(start));
+      misspelled_range->Set(Nan::New("end").ToLocalChecked(), Nan::New<Integer>(end));
+      result->Set(index, misspelled_range);
     }
 
     info.GetReturnValue().Set(result);

--- a/src/main.cc
+++ b/src/main.cc
@@ -57,9 +57,11 @@ class Spellchecker : public Nan::ObjectWrap {
     }
 
     Spellchecker* that = Nan::ObjectWrap::Unwrap<Spellchecker>(info.Holder());
-    String::Utf8Value text(info[0]);
+    Handle<String> string = Handle<String>::Cast(info[0]);
+    std::vector<uint16_t> text(string->Length());
+    string->Write(reinterpret_cast<uint16_t *>(text.data()));
 
-    std::vector<MisspelledRange> misspelled_ranges = that->impl->CheckSpelling(*text, text.length());
+    std::vector<MisspelledRange> misspelled_ranges = that->impl->CheckSpelling(text.data(), text.size());
 
     Local<Array> result = Nan::New<Array>();
     std::vector<MisspelledRange>::const_iterator iter = misspelled_ranges.begin();

--- a/src/main.cc
+++ b/src/main.cc
@@ -68,7 +68,7 @@ class Spellchecker : public Nan::ObjectWrap {
       return;
     }
 
-    std::vector<uint16_t> text(string->Length());
+    std::vector<uint16_t> text(string->Length() + 1);
     string->Write(reinterpret_cast<uint16_t *>(text.data()));
 
     Spellchecker* that = Nan::ObjectWrap::Unwrap<Spellchecker>(info.Holder());

--- a/src/spellchecker.h
+++ b/src/spellchecker.h
@@ -6,6 +6,11 @@
 
 namespace spellchecker {
 
+struct MisspelledRange {
+  size_t start;
+  size_t end;
+};
+
 class SpellcheckerImplementation {
 public:
   virtual bool SetDictionary(const std::string& language, const std::string& path) = 0;
@@ -16,6 +21,8 @@ public:
 
   // Returns true if the word is misspelled.
   virtual bool IsMisspelled(const std::string& word) = 0;
+
+  virtual std::vector<MisspelledRange> CheckSpelling(const char *text, size_t length) = 0;
 
   // Adds a new word to the dictionary.
   // NB: When using Hunspell, this will not modify the .dic file; custom words must be added each

--- a/src/spellchecker.h
+++ b/src/spellchecker.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 namespace spellchecker {
 
@@ -22,7 +23,7 @@ public:
   // Returns true if the word is misspelled.
   virtual bool IsMisspelled(const std::string& word) = 0;
 
-  virtual std::vector<MisspelledRange> CheckSpelling(const char *text, size_t length) = 0;
+  virtual std::vector<MisspelledRange> CheckSpelling(const uint16_t *text, size_t length) = 0;
 
   // Adds a new word to the dictionary.
   // NB: When using Hunspell, this will not modify the .dic file; custom words must be added each

--- a/src/spellchecker_hunspell.cc
+++ b/src/spellchecker_hunspell.cc
@@ -48,6 +48,11 @@ bool HunspellSpellchecker::IsMisspelled(const std::string& word) {
   return hunspell->spell(word.c_str()) == 0;
 }
 
+std::vector<MisspelledRange> HunspellSpellchecker::CheckSpelling(const char *text, size_t length) {
+  std::vector<MisspelledRange> result;
+  return result;
+}
+
 void HunspellSpellchecker::Add(const std::string& word) {
   if (hunspell) {
     hunspell->add(word.c_str());

--- a/src/spellchecker_hunspell.cc
+++ b/src/spellchecker_hunspell.cc
@@ -1,6 +1,8 @@
 #include <cstdio>
+#include <cwctype>
 #include <algorithm>
 #include "../vendor/hunspell/src/hunspell/hunspell.hxx"
+#include "../vendor/hunspell/src/hunspell/csutil.hxx"
 #include "spellchecker_hunspell.h"
 
 namespace spellchecker {
@@ -48,7 +50,7 @@ bool HunspellSpellchecker::IsMisspelled(const std::string& word) {
   return hunspell->spell(word.c_str()) == 0;
 }
 
-std::vector<MisspelledRange> HunspellSpellchecker::CheckSpelling(const char *text, size_t length) {
+std::vector<MisspelledRange> HunspellSpellchecker::CheckSpelling(const uint16_t *utf16_text, size_t utf16_length) {
   std::vector<MisspelledRange> result;
   return result;
 }

--- a/src/spellchecker_hunspell.cc
+++ b/src/spellchecker_hunspell.cc
@@ -60,17 +60,15 @@ std::vector<MisspelledRange> HunspellSpellchecker::CheckSpelling(const uint16_t 
   std::vector<char> utf8_buffer(256);
   char *utf8_word = utf8_buffer.data();
 
-  bool within_word = false;
   size_t word_start = 0;
-  for (size_t i = 0; i <= utf16_length; i++) {
-    bool is_alpha = i < utf16_length && std::iswalpha(utf16_text[i]);
-
+  bool within_word = false;
+  for (size_t i = 0; i < utf16_length; i++) {
+    bool is_word_character = iswalpha(utf16_text[i]);
     if (within_word) {
-      if (!is_alpha) {
+      if (!is_word_character) {
         within_word = false;
         const w_char *utf16_word = reinterpret_cast<const w_char *>(utf16_text + word_start);
         u16_u8(utf8_word, utf8_buffer.size(), utf16_word, i - word_start);
-
         if (hunspell->spell(utf8_word) == 0) {
           MisspelledRange range;
           range.start = word_start;
@@ -78,7 +76,7 @@ std::vector<MisspelledRange> HunspellSpellchecker::CheckSpelling(const uint16_t 
           result.push_back(range);
         }
       }
-    } else if (is_alpha) {
+    } else if (is_word_character) {
       word_start = i;
       within_word = true;
     }

--- a/src/spellchecker_hunspell.h
+++ b/src/spellchecker_hunspell.h
@@ -2,6 +2,7 @@
 #define SRC_SPELLCHECKER_HUNSPELL_H_
 
 #include "spellchecker.h"
+#include "transcoder.h"
 
 class Hunspell;
 
@@ -21,6 +22,7 @@ public:
 
 private:
   Hunspell* hunspell;
+  Transcoder *transcoder;
 };
 
 }  // namespace spellchecker

--- a/src/spellchecker_hunspell.h
+++ b/src/spellchecker_hunspell.h
@@ -16,6 +16,7 @@ public:
   std::vector<std::string> GetAvailableDictionaries(const std::string& path);
   std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
   bool IsMisspelled(const std::string& word);
+  std::vector<MisspelledRange> CheckSpelling(const char *text, size_t length);
   void Add(const std::string& word);
 
 private:

--- a/src/spellchecker_hunspell.h
+++ b/src/spellchecker_hunspell.h
@@ -16,7 +16,7 @@ public:
   std::vector<std::string> GetAvailableDictionaries(const std::string& path);
   std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
   bool IsMisspelled(const std::string& word);
-  std::vector<MisspelledRange> CheckSpelling(const char *text, size_t length);
+  std::vector<MisspelledRange> CheckSpelling(const uint16_t *text, size_t length);
   void Add(const std::string& word);
 
 private:

--- a/src/spellchecker_mac.h
+++ b/src/spellchecker_mac.h
@@ -17,6 +17,7 @@ public:
   std::vector<std::string> GetAvailableDictionaries(const std::string& path);
   std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
   bool IsMisspelled(const std::string& word);
+  std::vector<MisspelledRange> CheckSpelling(const char *text, size_t length);
   void Add(const std::string& word);
 
 private:

--- a/src/spellchecker_mac.h
+++ b/src/spellchecker_mac.h
@@ -17,7 +17,7 @@ public:
   std::vector<std::string> GetAvailableDictionaries(const std::string& path);
   std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
   bool IsMisspelled(const std::string& word);
-  std::vector<MisspelledRange> CheckSpelling(const char *text, size_t length);
+  std::vector<MisspelledRange> CheckSpelling(const uint16_t *text, size_t length);
   void Add(const std::string& word);
 
 private:

--- a/src/spellchecker_mac.mm
+++ b/src/spellchecker_mac.mm
@@ -52,6 +52,23 @@ bool MacSpellchecker::IsMisspelled(const std::string& word) {
   return result;
 }
 
+std::vector<MisspelledRange> MacSpellchecker::CheckSpelling(const char *text, size_t length) {
+  std::vector<MisspelledRange> result;
+
+  @autoreleasepool {
+    NSString* string = [NSString stringWithUTF8String:text];
+    NSArray *misspellings = [this->spellChecker checkString:string range:NSMakeRange(0, length) types:NSTextCheckingTypeSpelling options:nil inSpellDocumentWithTag:0 orthography:nil wordCount:nil];
+    for (NSTextCheckingResult *misspelling in misspellings) {
+      MisspelledRange range;
+      range.start = misspelling.range.location;
+      range.end = misspelling.range.location + misspelling.range.length;
+      result.push_back(range);
+    }
+  }
+
+  return result;
+}
+
 void MacSpellchecker::Add(const std::string& word) {
   @autoreleasepool {
     NSString* newWord = [NSString stringWithUTF8String:word.c_str()];

--- a/src/spellchecker_mac.mm
+++ b/src/spellchecker_mac.mm
@@ -57,7 +57,13 @@ std::vector<MisspelledRange> MacSpellchecker::CheckSpelling(const char *text, si
 
   @autoreleasepool {
     NSString* string = [NSString stringWithUTF8String:text];
-    NSArray *misspellings = [this->spellChecker checkString:string range:NSMakeRange(0, length) types:NSTextCheckingTypeSpelling options:nil inSpellDocumentWithTag:0 orthography:nil wordCount:nil];
+    NSArray *misspellings = [this->spellChecker checkString:string
+                                                      range:NSMakeRange(0, length)
+                                                      types:NSTextCheckingTypeSpelling
+                                                    options:nil
+                                     inSpellDocumentWithTag:0
+                                                orthography:nil
+                                                  wordCount:nil];
     for (NSTextCheckingResult *misspelling in misspellings) {
       MisspelledRange range;
       range.start = misspelling.range.location;

--- a/src/spellchecker_mac.mm
+++ b/src/spellchecker_mac.mm
@@ -52,13 +52,14 @@ bool MacSpellchecker::IsMisspelled(const std::string& word) {
   return result;
 }
 
-std::vector<MisspelledRange> MacSpellchecker::CheckSpelling(const char *text, size_t length) {
+std::vector<MisspelledRange> MacSpellchecker::CheckSpelling(const uint16_t *text, size_t length) {
   std::vector<MisspelledRange> result;
 
   @autoreleasepool {
-    NSString* string = [NSString stringWithUTF8String:text];
+    NSData *data = [[NSData alloc] initWithBytesNoCopy:(void *)(text) length:(length * 2) freeWhenDone:NO];
+    NSString* string = [[NSString alloc] initWithData:data encoding:NSUTF16LittleEndianStringEncoding];
     NSArray *misspellings = [this->spellChecker checkString:string
-                                                      range:NSMakeRange(0, length)
+                                                      range:NSMakeRange(0, string.length)
                                                       types:NSTextCheckingTypeSpelling
                                                     options:nil
                                      inSpellDocumentWithTag:0

--- a/src/spellchecker_win.cc
+++ b/src/spellchecker_win.cc
@@ -187,7 +187,7 @@ bool WindowsSpellchecker::IsMisspelled(const std::string& word) {
   return ret;
 }
 
-std::vector<MisspelledRange> WindowsSpellchecker::CheckSpelling(const char *text, size_t length) {
+std::vector<MisspelledRange> WindowsSpellchecker::CheckSpelling(const uint16_t *text, size_t length) {
   std::vector<MisspelledRange> result;
 
   if (this->currentSpellchecker == NULL) {
@@ -195,7 +195,7 @@ std::vector<MisspelledRange> WindowsSpellchecker::CheckSpelling(const char *text
   }
 
   IEnumSpellingError* errors = NULL;
-  std::wstring wtext = ToWString(text);
+  std::wstring wtext(reinterpret_cast<const wchar_t *>(text), length);
   if (FAILED(this->currentSpellchecker->Check(wtext.c_str(), &errors))) {
     return result;
   }

--- a/src/spellchecker_win.h
+++ b/src/spellchecker_win.h
@@ -18,6 +18,7 @@ public:
 
   std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
   bool IsMisspelled(const std::string& word);
+  std::vector<MisspelledRange> CheckSpelling(const char *text, size_t length);
   void Add(const std::string& word);
 
 private:

--- a/src/spellchecker_win.h
+++ b/src/spellchecker_win.h
@@ -18,7 +18,7 @@ public:
 
   std::vector<std::string> GetCorrectionsForMisspelling(const std::string& word);
   bool IsMisspelled(const std::string& word);
-  std::vector<MisspelledRange> CheckSpelling(const char *text, size_t length);
+  std::vector<MisspelledRange> CheckSpelling(const uint16_t *text, size_t length);
   void Add(const std::string& word);
 
 private:

--- a/src/transcoder.h
+++ b/src/transcoder.h
@@ -1,0 +1,17 @@
+#ifndef SRC_TRANSCODER_H_
+#define SRC_TRANSCODER_H_
+
+#include <stdlib.h>
+#include <stdint.h>
+
+namespace spellchecker {
+
+struct Transcoder;
+
+Transcoder *NewTranscoder();
+void FreeTranscoder(Transcoder *);
+bool TranscodeUTF16ToUTF8(const Transcoder *, char *out, size_t out_length, const uint16_t *in, size_t in_length);
+
+}  // namespace spellchecker
+
+#endif  // SRC_TRANSCODER_H_

--- a/src/transcoder_posix.cc
+++ b/src/transcoder_posix.cc
@@ -1,0 +1,59 @@
+#include <iconv.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+namespace spellchecker {
+
+struct Transcoder {
+  iconv_t conversion;
+};
+
+static int IsBigEndian(void) {
+  union {
+    uint16_t integer;
+    char bytes[2];
+  } two_byte_value;
+
+  two_byte_value.integer = {0x0102};
+  return two_byte_value.bytes[0] == 1;
+}
+
+Transcoder *NewTranscoder() {
+  const char *to_encoding = "UTF-8";
+  const char *from_encoding = IsBigEndian() ? "UTF-16BE" : "UTF-16LE";
+  iconv_t conversion = iconv_open(to_encoding, from_encoding);
+  if (conversion == (iconv_t)-1) {
+    return NULL;
+  }
+
+  Transcoder *result = new Transcoder();
+  result->conversion = conversion;
+  return result;
+}
+
+void FreeTranscoder(Transcoder *transcoder) {
+  iconv_close(transcoder->conversion);
+  delete transcoder;
+}
+
+bool TranscodeUTF16ToUTF8(const Transcoder *transcoder, char *out, size_t out_bytes, const uint16_t *in, size_t in_length) {
+  char *utf16_word = reinterpret_cast<char *>(const_cast<uint16_t *>(in));
+  size_t utf16_bytes = in_length * (sizeof(uint16_t) / sizeof(char));
+
+  size_t iconv_result = iconv(
+    transcoder->conversion,
+    &utf16_word,
+    &utf16_bytes,
+    &out,
+    &out_bytes
+  );
+
+  if (iconv_result == static_cast<size_t>(-1)) {
+    return false;
+  }
+
+  *out = '\0';
+  return true;
+}
+
+}  // namespace spellchecker

--- a/src/transcoder_win.cc
+++ b/src/transcoder_win.cc
@@ -1,0 +1,23 @@
+#include <windows.h>
+#include <stdlib.h>
+#include "transcoder.h"
+
+namespace spellchecker {
+
+struct Transcoder {};
+
+Transcoder* NewTranscoder() {
+  return new Transcoder();
+}
+
+void FreeTranscoder(Transcoder *transcoder) {
+  delete transcoder;
+}
+
+bool TranscodeUTF16ToUTF8(const Transcoder *transcoder, char *out, size_t out_length, const uint16_t *in, size_t in_length) {
+  int length = WideCharToMultiByte(CP_UTF8, 0, reinterpret_cast<const wchar_t *>(in), in_length, out, out_length, NULL, NULL);
+  out[length] = '\0';
+  return true;
+}
+
+}  // namespace spellchecker


### PR DESCRIPTION
Fixes https://github.com/atom/spell-check/issues/99
Fixes https://github.com/atom/spell-check/issues/53
Supercedes https://github.com/atom/spell-check/pull/100

Depends on https://github.com/atom/node-spellchecker/pull/28
Refs https://github.com/atom/spell-check/issues/53
Refs https://github.com/atom/atom/issues/8908

When opening a large plain text file, Atom's spell check task takes a very long time to process the file. When I open `/usr/share/dict/words`, which contains 235,886 words, one per line, the spell check task runs for 95 seconds.

##### Source of the slowness

On Mac, spell checking is implemented by calling into the central `AppleSpell` process, so there is some IPC overhead for each spell-checking call.

There seem to be some overhead for each spell check call on Windows too, as I'm seeing a 2X improvement there. On Linux, our existing code was already fine.

##### Solution

This PR adds a new native API, `Spellchecker.checkSpelling(string)`, which takes a multi-word string and returns an array of character ranges representing all of the misspelled words. This way, the spell-checking can be performed in a single shot.

##### TODO

* [x] Mac
* [x] Windows
* [x] Linux
* [x] Account for paired characters, since native spell checkers will return indices in terms of logical code points, not Javascript's 2-byte values.

##### Speedup

On my machine, spell-checking `/usr/share/dict/words` now takes about 11 seconds: ~9X faster than before. This is now short enough that my CPU fan stays quiet.

##### Questions

This may cause some subtle behavior change, because the platform's spell-checking library will now be in charge of partitioning the text into words, rather than handling that in JS. This doesn't seem like a huge problem to me, but maybe someone else has some insight into this.

/cc @atom/feedback 