### PR TITLE
Allow hunspell implementation to be used on OSX

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,9 +1,14 @@
 {
   'variables': {
-    'spellchecker_use_hunspell': 'true',
     'conditions': [
       ['OS=="mac"', {
-        'spellchecker_use_hunspell': 'false',
+        'spellchecker_use_hunspell%': 'false',
+      }],
+      ['OS=="linux"', {
+        'spellchecker_use_hunspell': 'true',
+      }],
+      ['OS=="win"', {
+        'spellchecker_use_hunspell': 'true',
       }],
     ],
   },

--- a/src/spellchecker_mac.mm
+++ b/src/spellchecker_mac.mm
@@ -1,4 +1,5 @@
 #include "spellchecker_mac.h"
+#include "spellchecker_hunspell.h"
 
 #import <Cocoa/Cocoa.h>
 #import <dispatch/dispatch.h>
@@ -85,6 +86,12 @@ std::vector<std::string> MacSpellchecker::GetCorrectionsForMisspelling(const std
 }
 
 SpellcheckerImplementation* SpellcheckerFactory::CreateSpellchecker() {
+#ifdef USE_HUNSPELL
+  if (getenv("SPELLCHECKER_PREFER_HUNSPELL")) {
+    return new HunspellSpellchecker();
+  }
+#endif
+
   return new MacSpellchecker();
 }
 


### PR DESCRIPTION
Currently, the Hunspell spell-checker implementation is built on Linux and Windows, but not on OSX. On Windows, users can choose to use Hunspell at runtime by setting the `SPELLCHECKER_PREFER_HUNSPELL` environment variable.

Now, when installing the library on Mac, you can choose to compile it with Hunspell support by running this:
```
node-gyp rebuild -- -D spellchecker_use_hunspell=true
```

If you do that, then you can choose Hunspell at runtime via the environment variable, similar to the windows version.

I chose not to include hunspell in the binary by default, since most Mac users won't need it, and it lengthens the build time and the binary size. I just needed so I could work on the Hunspell implementation on my Mac.

/cc @paulcbetts @kevinsawicki