### PR TITLE
Use sharedSpellChecker on OS X

### DIFF
--- a/src/spellchecker_mac.mm
+++ b/src/spellchecker_mac.mm
@@ -8,14 +8,12 @@ namespace spellchecker {
 
 
 MacSpellchecker::MacSpellchecker() {
-  this->spellChecker = [[NSSpellChecker alloc] init];
+  this->spellChecker = [NSSpellChecker sharedSpellChecker];
   [this->spellChecker setAutomaticallyIdentifiesLanguages: NO];
 }
 
 MacSpellchecker::~MacSpellchecker() {
-  [this->spellChecker release];
 }
-
 
 bool MacSpellchecker::SetDictionary(const std::string& language, const std::string& path) {
   @autoreleasepool {


### PR DESCRIPTION
Mac OS X's `NSSpellChecker` documentation suggests that you should use `sharedSpellChecker` rather than `alloc + init`. This PR switches to that approach, and fixes the crashes documented in issue #30. I also checked (via the code in that issue) that you can change the configuration of the `sharedSpellChecker` at runtime. It doesn't seem creating a second instance was really necessary.

As a side note, I think this is a bug in Mac OS X — as far as I can tell node-spellchecker was doing everything correctly and `init` should really throw an exception if using `sharedSpellChecker` is required...

https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSSpellChecker_Class/#//apple_ref/occ/clm/NSSpellChecker/sharedSpellChecker