### PR TITLE
use system $LANG in preference to en_US

### DIFF
--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -21,7 +21,8 @@ var ensureDefaultSpellCheck = function() {
     return;
   }
 
-  var lang = process.env.LANG.split('.')[0] || 'en_US';
+  var lang = process.env.LANG;
+  lang = lang ? lang.split('.')[0] : 'en_US';
   setDictionary(lang, getDictionaryPath());
 };
 

--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -20,7 +20,12 @@ var ensureDefaultSpellCheck = function() {
   if (defaultSpellcheck) {
     return;
   }
-  setDictionary('en_US', getDictionaryPath());
+
+  var lang = process.env.LANG.split('.')[0];
+  if (!lang){
+    lang = 'en_US';
+  }
+  setDictionary(lang, getDictionaryPath());
 };
 
 var isMisspelled = function() {

--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -21,10 +21,7 @@ var ensureDefaultSpellCheck = function() {
     return;
   }
 
-  var lang = process.env.LANG.split('.')[0];
-  if (!lang){
-    lang = 'en_US';
-  }
+  var lang = process.env.LANG.split('.')[0] || 'en_US';
   setDictionary(lang, getDictionaryPath());
 };
 


### PR DESCRIPTION
If `$LANG` is set, no need to force `en_US`, even just as a default.

This marginally improves the situation in atom/spell-check#21.