### PR TITLE
Fetch available Library languages

### DIFF
--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -1,6 +1,6 @@
 var path = require('path');
 var loophole = require('loophole');
-var bindings = require('../build/Release/spellchecker.node');
+var bindings = require('bindings')('spellchecker.node');
 
 var Spellchecker = bindings.Spellchecker;
 

--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -1,9 +1,22 @@
 var path = require('path');
+var loophole = require('loophole');
 var bindings = require('../build/Release/spellchecker.node');
 
 var Spellchecker = bindings.Spellchecker;
 
 var defaultSpellcheck = null;
+
+var objc, pool;
+
+// Workaround NSSpellChecker bug
+// http://stackoverflow.com/a/31383060
+loophole.allowUnsafeNewFunction(function () {
+  objc = require('nodobjc')
+  objc.import('Cocoa');
+  pool = objc.NSAutoreleasePool('alloc')('init');
+  objc.NSApplication('sharedApplication');
+  pool('release');
+});
 
 var setDictionary = function(lang, dictPath) {
   defaultSpellcheck = new Spellchecker();

--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -11,11 +11,13 @@ var objc, pool;
 // Workaround NSSpellChecker bug
 // http://stackoverflow.com/a/31383060
 loophole.allowUnsafeNewFunction(function () {
-  objc = require('nodobjc')
-  objc.import('Cocoa');
-  pool = objc.NSAutoreleasePool('alloc')('init');
-  objc.NSApplication('sharedApplication');
-  pool('release');
+  try {
+    objc = require('nodobjc')
+    objc.import('Cocoa');
+    pool = objc.NSAutoreleasePool('alloc')('init');
+    objc.NSApplication('sharedApplication');
+    pool('release');
+  } catch (ex) {}
 });
 
 var setDictionary = function(lang, dictPath) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "jasmine-focused": "1.x"
   },
   "dependencies": {
+    "bindings": "^1.2.1",
     "loophole": "^1.1.0",
     "nan": "^2.0.0",
     "nodobjc": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "jasmine-focused": "1.x"
   },
   "dependencies": {
-    "nan": "^2.0.0"
+    "loophole": "^1.1.0",
+    "nan": "^2.0.0",
+    "nodobjc": "^2.1.0"
   }
 }


### PR DESCRIPTION
`[NSSpellChecker availableLanguages]` doesn't load spelling dictionaries from Library/Spelling. This [SO comment](http://stackoverflow.com/a/31383060) states that this may be a bug. Apparently the bug doesn't exist in Cocoa apps so I created straight forward, albeit very slow workaround.

This issue definitely needs further investigation and smarter workaround, for example first check Library/Spelling directories if custom dictionaries does exist at all.