### PR TITLE
fix(getURLForHunspellDictionary): return correct url for some non-formed bdict

### DIFF
--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -20,16 +20,16 @@ var ensureDefaultSpellCheck = function() {
 
 var setDictionary = function(lang, dictPath) {
   ensureDefaultSpellCheck();
-  
+
   var filePath = path.join(dictPath, lang.replace(/_/g, '-') + '.bdic');
   var contents = null;
-  
+
   try {
     contents = fs.readFileSync(filePath);
   } catch (e) {
     return false;
   }
-  
+
   return defaultSpellcheck.setDictionary(lang, contents);
 };
 
@@ -85,8 +85,19 @@ var getURLForHunspellDictionary = function(lang) {
     'en-us': '-7-1',
     'fa-ir': '-7-0',
   };
-  
+
+  var nonFormedLangCode = ['ko', 'sh', 'sq', 'sr'];
   var langCode = lang.replace(/_/g, '-').toLowerCase();
+
+  //some bdict in choromium does not follow form of language code with locale,
+  //formed as language only (i.e, https://src.chromium.org/viewvc/chrome/trunk/deps/third_party/hunspell_dictionaries/ko-3-0.bdic)
+  var language = langCode.split('-')[0];
+  for (var idx = 0; idx < nonFormedLangCode.length; idx++) {
+    if (language === nonFormedLangCode[idx]) {
+      langCode = nonFormedLangCode[idx];
+    }
+  }
+
   return "https://redirector.gvt1.com/edgedl/chrome/dict/" + langCode + (specialVersions[langCode] || defaultVersion) + ".bdic";
 }
 


### PR DESCRIPTION
This PR updates `getURLForHunspellDictionary` to return correct url for some bdict dictionaries. For some languages, choromium has corresponding bdict but not formed as language/locale based languagecode, but only using language like https://src.chromium.org/viewvc/chrome/trunk/deps/third_party/hunspell_dictionaries/ko-3-0.bdic . If given langCode falls into those category, generate url to corresponding manner.