### PR TITLE
Search for globally available dictionaries (on non-windows systems)

### DIFF
--- a/src/spellchecker_hunspell.h
+++ b/src/spellchecker_hunspell.h
@@ -24,6 +24,9 @@ public:
 private:
   Hunspell* hunspell;
   Transcoder *transcoder;
+
+  std::vector<std::string> SearchAvailableDictionaries(const std::string& path);
+  std::string FindDictionary(const std::string& path, const std::string& language, const std::string& extension);
 };
 
 }  // namespace spellchecker


### PR DESCRIPTION
When using `GetAvailableDictionaries` or `SetDictionary`, it will search in the given path or known locations where hunspell dictionaries are typically located (`/usr/share/hunspell` for example.)

This fixes #51 and #54.

No windows support yet :disappointed: 

I've used this script to test it out:

```node
c = require ('./lib/spellchecker');

console.log(c.setDictionary('nl_NL', ''));
console.log(c.checkSpelling('kaas cheese dingen false'));
console.log(c.getCorrectionsForMisspelling('cheese'));
console.log(c.getCorrectionsForMisspelling('false'));

console.log(c.getAvailableDictionaries());
```

On my machine, this results in:

```
true
[ { start: 5, end: 11 }, { start: 19, end: 24 } ]
[ 'Heesch', 'Scheeres', 'schee', 'speeches' ]
[ 'valse', 'fase', 'falset', 'falie', 'malse', 'Kalse', 'Fasel' ]
[ 'nl_BE',
  'nl_NL',
  'en_US',
  'en_GB',
  'hyph_en_US',
  'hyph_en_CA',
  'hyph_ga_IE',
  'hyph_fi_FI',
  'hyph_id_ID' ]
```


Please note that I am not an experienced C++ programmer, so I might do some weird stuff. I'd love to know if anything seems weird and how to fix it.