### PR TITLE
Asynchronous checkSpelling API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ Get the corrections for a misspelled word.
 
 Returns a non-null but possibly empty array of string corrections.
 
+### SpellChecker.checkSpelling(corpus)
+
+Identify misspelled words in a corpus of text.
+
+`corpus` - String corpus of text to spellcheck.
+
+Returns an Array containing `{start, end}` objects that describe an index range within the original String that contains a misspelled word.
+
+### SpellChecker.checkSpellingAsync(corpus)
+
+Asynchronously identify misspelled words.
+
+`corpus` - String corpus of text to spellcheck.
+
+Returns a Promise that resolves with the Array described by `checkSpelling()`.
+
 ### SpellChecker.add(word)
 
 Adds a word to the dictionary.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  nodejs_version: "0.10"
+  nodejs_version: "6"
 
   matrix:
     - {}

--- a/binding.gyp
+++ b/binding.gyp
@@ -29,6 +29,7 @@
       'include_dirs': [ '<!(node -e "require(\'nan\')")' ],
       'sources': [
         'src/main.cc',
+        'src/worker.cc'
       ],
       'conditions': [
         ['spellchecker_use_hunspell=="true"', {

--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -1,18 +1,19 @@
 var path = require('path');
+var Promise = require('any-promise');
 var bindings = require('../build/Release/spellchecker.node');
 
 var Spellchecker = bindings.Spellchecker;
 
 Spellchecker.prototype.checkSpellingAsync = function (corpus) {
-  return new Promise((resolve, reject) => {
-    this.checkSpellingCallback(corpus, (err, result) => {
+  return new Promise(function (resolve, reject) {
+    this.checkSpellingCallback(corpus, function (err, result) {
       if (err) {
         reject(err);
       } else {
         resolve(result);
       }
     })
-  });
+  }.bind(this));
 };
 
 var defaultSpellcheck = null;

--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -3,6 +3,18 @@ var bindings = require('../build/Release/spellchecker.node');
 
 var Spellchecker = bindings.Spellchecker;
 
+Spellchecker.prototype.checkSpellingAsync = function (corpus) {
+  return new Promise((resolve, reject) => {
+    this.checkSpellingCallback(corpus, (err, result) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(result);
+      }
+    })
+  });
+};
+
 var defaultSpellcheck = null;
 
 var ensureDefaultSpellCheck = function() {
@@ -32,6 +44,14 @@ var checkSpelling = function() {
   ensureDefaultSpellCheck();
 
   return defaultSpellcheck.checkSpelling.apply(defaultSpellcheck, arguments);
+};
+
+var checkSpellingAsync = function(corpus) {
+  ensureDefaultSpellCheck();
+
+  return new Promise(function (resolve) {
+    defaultSpellcheck.checkSpellingAsync.apply(defaultSpellcheck, corpus, resolve);
+  });
 };
 
 var add = function() {
@@ -77,6 +97,7 @@ module.exports = {
   remove: remove,
   isMisspelled: isMisspelled,
   checkSpelling: checkSpelling,
+  checkSpellingAsync: checkSpellingAsync,
   getAvailableDictionaries: getAvailableDictionaries,
   getCorrectionsForMisspelling: getCorrectionsForMisspelling,
   Spellchecker: Spellchecker

--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -4,15 +4,17 @@ var bindings = require('../build/Release/spellchecker.node');
 
 var Spellchecker = bindings.Spellchecker;
 
+var checkSpellingAsyncCb = Spellchecker.prototype.checkSpellingAsync
+
 Spellchecker.prototype.checkSpellingAsync = function (corpus) {
   return new Promise(function (resolve, reject) {
-    this.checkSpellingCallback(corpus, function (err, result) {
+    checkSpellingAsyncCb.call(this, corpus, function (err, result) {
       if (err) {
         reject(err);
       } else {
         resolve(result);
       }
-    })
+    });
   }.bind(this));
 };
 
@@ -50,9 +52,7 @@ var checkSpelling = function() {
 var checkSpellingAsync = function(corpus) {
   ensureDefaultSpellCheck();
 
-  return new Promise(function (resolve) {
-    defaultSpellcheck.checkSpellingAsync.apply(defaultSpellcheck, corpus, resolve);
-  });
+  return defaultSpellcheck.checkSpellingAsync.apply(defaultSpellcheck, arguments);
 };
 
 var add = function() {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "jasmine-focused": "1.x"
   },
   "dependencies": {
+    "any-promise": "^1.3.0",
     "nan": "^2.0.0"
   }
 }

--- a/spec/spellchecker-spec.coffee
+++ b/spec/spellchecker-spec.coffee
@@ -134,9 +134,11 @@ describe "SpellChecker", ->
       @fixture.setDictionary defaultLanguage, dictionaryDirectory
 
     it "returns an array of possible corrections", ->
-      corrections = @fixture.getCorrectionsForMisspelling('wordd')
+      correction = if process.platform is "darwin" then "world" else "word"
+
+      corrections = @fixture.getCorrectionsForMisspelling('worrd')
       expect(corrections.length).toBeGreaterThan 0
-      expect(corrections.indexOf('words')).toBeGreaterThan -1
+      expect(corrections.indexOf(correction)).toBeGreaterThan -1
 
     it "throws an exception when no word specified", ->
       expect(-> @fixture.getCorrectionsForMisspelling()).toThrow()

--- a/spec/spellchecker-spec.coffee
+++ b/spec/spellchecker-spec.coffee
@@ -123,6 +123,11 @@ describe "SpellChecker", ->
           {start: 13, end: 18}
         ]
 
+    it "handles invalid inputs", ->
+      expect(=> @fixture.checkSpelling()).toThrow("Bad argument")
+      expect(=> @fixture.checkSpelling(null)).toThrow("Bad argument")
+      expect(=> @fixture.checkSpelling(47)).toThrow("Bad argument")
+
   describe ".getCorrectionsForMisspelling(word)", ->
     beforeEach ->
       @fixture = new Spellchecker()

--- a/spec/spellchecker-spec.coffee
+++ b/spec/spellchecker-spec.coffee
@@ -134,9 +134,9 @@ describe "SpellChecker", ->
       @fixture.setDictionary defaultLanguage, dictionaryDirectory
 
     it "returns an array of possible corrections", ->
-      corrections = @fixture.getCorrectionsForMisspelling('worrd')
+      corrections = @fixture.getCorrectionsForMisspelling('wordd')
       expect(corrections.length).toBeGreaterThan 0
-      expect(corrections.indexOf('word')).toBeGreaterThan -1
+      expect(corrections.indexOf('words')).toBeGreaterThan -1
 
     it "throws an exception when no word specified", ->
       expect(-> @fixture.getCorrectionsForMisspelling()).toThrow()

--- a/spec/spellchecker-spec.coffee
+++ b/spec/spellchecker-spec.coffee
@@ -104,6 +104,25 @@ describe "SpellChecker", ->
       expect(-> fixture.checkSpelling(null)).toThrow("Bad argument")
       expect(-> fixture.checkSpelling({})).toThrow("Bad argument")
 
+  describe ".checkSpellingAsync(string)", ->
+    beforeEach ->
+      @fixture = new Spellchecker()
+      @fixture.setDictionary defaultLanguage, dictionaryDirectory
+
+    it "returns an array of character ranges of misspelled words", ->
+      string = "cat caat dog dooog"
+      ranges = null
+
+      @fixture.checkSpellingAsync(string).then (r) -> ranges = r
+
+      waitsFor -> ranges is not null
+
+      runs ->
+        expect(ranges).toEqual [
+          {start: 4, end: 8}
+          {start: 13, end: 18}
+        ]
+
   describe ".getCorrectionsForMisspelling(word)", ->
     beforeEach ->
       @fixture = new Spellchecker()

--- a/spec/spellchecker-spec.coffee
+++ b/spec/spellchecker-spec.coffee
@@ -115,7 +115,7 @@ describe "SpellChecker", ->
 
       @fixture.checkSpellingAsync(string).then (r) -> ranges = r
 
-      waitsFor -> ranges is not null
+      waitsFor -> ranges isnt null
 
       runs ->
         expect(ranges).toEqual [

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,4 +1,5 @@
 #include <vector>
+#include <utility>
 #include "nan.h"
 #include "spellchecker.h"
 #include "worker.h"
@@ -100,12 +101,12 @@ class Spellchecker : public Nan::ObjectWrap {
 
     Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
 
-    std::vector<uint16_t> *corpus = new std::vector<uint16_t>(string->Length() + 1);
-    string->Write(reinterpret_cast<uint16_t *>(corpus->data()));
+    std::vector<uint16_t> corpus(string->Length() + 1);
+    string->Write(reinterpret_cast<uint16_t *>(corpus.data()));
 
     Spellchecker* that = Nan::ObjectWrap::Unwrap<Spellchecker>(info.Holder());
 
-    CheckSpellingWorker* worker = new CheckSpellingWorker(corpus, that->impl, callback);
+    CheckSpellingWorker* worker = new CheckSpellingWorker(std::move(corpus), that->impl, callback);
     Nan::AsyncQueueWorker(worker);
   }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -87,7 +87,7 @@ class Spellchecker : public Nan::ObjectWrap {
     }
   }
 
-  static NAN_METHOD(CheckSpellingCallback) {
+  static NAN_METHOD(CheckSpellingAsync) {
     Nan::HandleScope scope;
     if (info.Length() < 2) {
       return Nan::ThrowError("Bad argument");
@@ -98,7 +98,7 @@ class Spellchecker : public Nan::ObjectWrap {
       return Nan::ThrowError("Bad argument");
     }
 
-    Nan::Callback *callback = new Nan::Callback(info[1].As<v8::Function>());
+    Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
 
     std::vector<uint16_t> *corpus = new std::vector<uint16_t>(string->Length() + 1);
     string->Write(reinterpret_cast<uint16_t *>(corpus->data()));
@@ -197,14 +197,14 @@ class Spellchecker : public Nan::ObjectWrap {
     tpl->SetClassName(Nan::New<String>("Spellchecker").ToLocalChecked());
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-    Nan::SetMethod(tpl->InstanceTemplate(), "setDictionary", Spellchecker::SetDictionary);
-    Nan::SetMethod(tpl->InstanceTemplate(), "getAvailableDictionaries", Spellchecker::GetAvailableDictionaries);
-    Nan::SetMethod(tpl->InstanceTemplate(), "getCorrectionsForMisspelling", Spellchecker::GetCorrectionsForMisspelling);
-    Nan::SetMethod(tpl->InstanceTemplate(), "isMisspelled", Spellchecker::IsMisspelled);
-    Nan::SetMethod(tpl->InstanceTemplate(), "checkSpelling", Spellchecker::CheckSpelling);
-    Nan::SetMethod(tpl->InstanceTemplate(), "checkSpellingCallback", Spellchecker::CheckSpellingCallback);
-    Nan::SetMethod(tpl->InstanceTemplate(), "add", Spellchecker::Add);
-    Nan::SetMethod(tpl->InstanceTemplate(), "remove", Spellchecker::Remove);
+    Nan::SetPrototypeMethod(tpl, "setDictionary", Spellchecker::SetDictionary);
+    Nan::SetPrototypeMethod(tpl, "getAvailableDictionaries", Spellchecker::GetAvailableDictionaries);
+    Nan::SetPrototypeMethod(tpl, "getCorrectionsForMisspelling", Spellchecker::GetCorrectionsForMisspelling);
+    Nan::SetPrototypeMethod(tpl, "isMisspelled", Spellchecker::IsMisspelled);
+    Nan::SetPrototypeMethod(tpl, "checkSpelling", Spellchecker::CheckSpelling);
+    Nan::SetPrototypeMethod(tpl, "checkSpellingAsync", Spellchecker::CheckSpellingAsync);
+    Nan::SetPrototypeMethod(tpl, "add", Spellchecker::Add);
+    Nan::SetPrototypeMethod(tpl, "remove", Spellchecker::Remove);
 
     exports->Set(Nan::New("Spellchecker").ToLocalChecked(), tpl->GetFunction());
   }

--- a/src/spellchecker_win.cc
+++ b/src/spellchecker_win.cc
@@ -59,7 +59,7 @@ WindowsSpellchecker::WindowsSpellchecker() {
   this->currentSpellchecker = NULL;
 
   if (InterlockedIncrement(&g_COMRefcount) == 1) {
-    g_COMFailed = FAILED(CoInitialize(NULL));
+    g_COMFailed = FAILED(CoInitializeEx(NULL, COINIT_MULTITHREADED));
     if (g_COMFailed) return;
   }
 

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -5,12 +5,13 @@
 
 #include <string>
 #include <vector>
+#include <utility>
 
 CheckSpellingWorker::CheckSpellingWorker(
-  const std::vector<uint16_t>* corpus,
+  const std::vector<uint16_t>&& corpus,
   SpellcheckerImplementation* impl,
   Nan::Callback* callback
-) : AsyncWorker(callback), corpus(corpus), impl(impl)
+) : AsyncWorker(callback), corpus(std::move(corpus)), impl(impl)
 {
   // No-op
 }
@@ -21,7 +22,7 @@ CheckSpellingWorker::~CheckSpellingWorker()
 }
 
 void CheckSpellingWorker::Execute() {
-  misspelled_ranges = impl->CheckSpelling(corpus->data(), corpus->size());
+  misspelled_ranges = impl->CheckSpelling(corpus.data(), corpus.size());
 }
 
 void CheckSpellingWorker::HandleOKCallback() {

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -8,7 +8,7 @@
 #include <utility>
 
 CheckSpellingWorker::CheckSpellingWorker(
-  const std::vector<uint16_t>&& corpus,
+  std::vector<uint16_t>&& corpus,
   SpellcheckerImplementation* impl,
   Nan::Callback* callback
 ) : AsyncWorker(callback), corpus(std::move(corpus)), impl(impl)

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -29,8 +29,7 @@ void CheckSpellingWorker::HandleOKCallback() {
   Nan::HandleScope scope;
 
   Local<Array> result = Nan::New<Array>();
-  std::vector<MisspelledRange>::const_iterator iter = misspelled_ranges.begin();
-  for (; iter != misspelled_ranges.end(); ++iter) {
+  for (auto iter = misspelled_ranges.begin(); iter != misspelled_ranges.end(); ++iter) {
     size_t index = iter - misspelled_ranges.begin();
     uint32_t start = iter->start, end = iter->end;
 

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -1,0 +1,44 @@
+#include "worker.h"
+
+#include "nan.h"
+#include "spellchecker.h"
+
+#include <string>
+#include <vector>
+
+CheckSpellingWorker::CheckSpellingWorker(
+  const std::vector<uint16_t>* corpus,
+  SpellcheckerImplementation* impl,
+  Nan::Callback* callback
+) : AsyncWorker(callback), corpus(corpus), impl(impl)
+{
+  // No-op
+}
+
+CheckSpellingWorker::~CheckSpellingWorker()
+{
+  // No-op
+}
+
+void CheckSpellingWorker::Execute() {
+  misspelled_ranges = impl->CheckSpelling(corpus->data(), corpus->size());
+}
+
+void CheckSpellingWorker::HandleOKCallback() {
+  Nan::HandleScope scope;
+
+  Local<Array> result = Nan::New<Array>();
+  std::vector<MisspelledRange>::const_iterator iter = misspelled_ranges.begin();
+  for (; iter != misspelled_ranges.end(); ++iter) {
+    size_t index = iter - misspelled_ranges.begin();
+    uint32_t start = iter->start, end = iter->end;
+
+    Local<Object> misspelled_range = Nan::New<Object>();
+    misspelled_range->Set(Nan::New("start").ToLocalChecked(), Nan::New<Integer>(start));
+    misspelled_range->Set(Nan::New("end").ToLocalChecked(), Nan::New<Integer>(end));
+    result->Set(index, misspelled_range);
+  }
+
+  Local<Value> argv[] = { Nan::Null(), result };
+  callback->Call(2, argv);
+}

--- a/src/worker.h
+++ b/src/worker.h
@@ -1,0 +1,25 @@
+#ifndef WORKER_H
+#define WORKER_H
+
+#include "nan.h"
+#include "spellchecker.h"
+
+#include <vector>
+
+using namespace spellchecker;
+using namespace v8;
+
+class CheckSpellingWorker : public Nan::AsyncWorker {
+public:
+  CheckSpellingWorker(const std::vector<uint16_t>* corpus, SpellcheckerImplementation* impl, Nan::Callback* callback);
+  ~CheckSpellingWorker();
+
+  void Execute();
+  void HandleOKCallback();
+private:
+  const std::vector<uint16_t>* corpus;
+  SpellcheckerImplementation* impl;
+  std::vector<MisspelledRange> misspelled_ranges;
+};
+
+#endif

--- a/src/worker.h
+++ b/src/worker.h
@@ -11,13 +11,13 @@ using namespace v8;
 
 class CheckSpellingWorker : public Nan::AsyncWorker {
 public:
-  CheckSpellingWorker(const std::vector<uint16_t>* corpus, SpellcheckerImplementation* impl, Nan::Callback* callback);
+  CheckSpellingWorker(const std::vector<uint16_t> &&corpus, SpellcheckerImplementation* impl, Nan::Callback* callback);
   ~CheckSpellingWorker();
 
   void Execute();
   void HandleOKCallback();
 private:
-  const std::vector<uint16_t>* corpus;
+  const std::vector<uint16_t> corpus;
   SpellcheckerImplementation* impl;
   std::vector<MisspelledRange> misspelled_ranges;
 };

--- a/src/worker.h
+++ b/src/worker.h
@@ -11,7 +11,7 @@ using namespace v8;
 
 class CheckSpellingWorker : public Nan::AsyncWorker {
 public:
-  CheckSpellingWorker(const std::vector<uint16_t> &&corpus, SpellcheckerImplementation* impl, Nan::Callback* callback);
+  CheckSpellingWorker(std::vector<uint16_t> &&corpus, SpellcheckerImplementation* impl, Nan::Callback* callback);
   ~CheckSpellingWorker();
 
   void Execute();


### PR DESCRIPTION
Introduces a `checkSpellingAsync()` method that performs the same work as `checkSpelling()`, but in a background thread.

/cc @maxbrunsfeld for another set of eyes on my C++ because describing my C++ as "rusty" is generous.
/cc @damieng because this relates to our work on atom/spell-check#190.