### PR TITLE
Expose the internal dictionary path via getDictionaryPath().

### DIFF
--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -101,5 +101,6 @@ module.exports = {
   checkSpellingAsync: checkSpellingAsync,
   getAvailableDictionaries: getAvailableDictionaries,
   getCorrectionsForMisspelling: getCorrectionsForMisspelling,
+  getDictionaryPath: getDictionaryPath,
   Spellchecker: Spellchecker
 };


### PR DESCRIPTION
I'm working on a bug for Atom's `spell-check` where I need the path to the default dictionaries on a Windows platform. Since this needs to handle the ASAR archive processing, I figured it would be easier to expose the `getDictionaryPath()` directly instead of duplicating the search logic inside `spell-check`.

This patch just exposes the internal `getDictionaryPath()` function for consumption.