### PR TITLE
Fix broken build with Xcode 9

### DIFF
--- a/src/spellchecker_mac.mm
+++ b/src/spellchecker_mac.mm
@@ -180,7 +180,7 @@ std::vector<std::string> MacSpellchecker::GetCorrectionsForMisspelling(const std
 }
 
 void MacSpellchecker::UpdateGlobalSpellchecker() {
-  const NSString* autoLangauge = @"___AUTO_LANGUAGE";
+  NSString* autoLangauge = @"___AUTO_LANGUAGE";
   NSString* globalLang = currentGlobalLanguage ? currentGlobalLanguage : autoLangauge;
   NSString* ourLang = this->spellCheckerLanguage ? this->spellCheckerLanguage : autoLangauge;
 


### PR DESCRIPTION
If you're anything like me, Apple just updated your Xcode to version 9, which currently doesn't want to build `@paulcbetts/spellchecker`. The error isn't wrong, either:

```
  CXX(target) Release/obj.target/spellchecker/src/spellchecker_mac.o
../src/spellchecker_mac.mm:184:13: error: cannot initialize a variable of type 'NSString *' with an rvalue of type 'const NSString *'
  NSString* globalLang = currentGlobalLanguage ? currentGlobalLanguage : autoLangauge;
            ^            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/spellchecker_mac.mm:185:13: error: cannot initialize a variable of type 'NSString *' with an rvalue of type 'const NSString *'
  NSString* ourLang = this->spellCheckerLanguage ? this->spellCheckerLanguage : autoLangauge;
            ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR is tiny and fixes that issue.