### PR TITLE
Replace `v8::String::Utf8Value` with `Nan::Utf8String`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm --msvs_version=2013 install
+  - npm --msvs_version=2015 install
 
 test_script:
   - node --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,10 @@
 environment:
-  nodejs_version: "6"
-
   matrix:
-    - {}
-    - {SPELLCHECKER_PREFER_HUNSPELL: true}
+    - nodejs_version: '10'
+    - nodejs_version: '10'
+      SPELLCHECKER_PREFER_HUNSPELL: true
+    - nodejs_version: '8'
+    - nodejs_version: '6'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "any-promise": "^1.3.0",
-    "nan": "^2.0.0"
+    "nan": "^2.10.0"
   }
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -30,10 +30,10 @@ class Spellchecker : public Nan::ObjectWrap {
 
     Spellchecker* that = Nan::ObjectWrap::Unwrap<Spellchecker>(info.Holder());
 
-    std::string language = *String::Utf8Value(info[0]);
+    std::string language = *Nan::Utf8String(info[0]);
     std::string directory = ".";
     if (info.Length() > 1) {
-      directory = *String::Utf8Value(info[1]);
+      directory = *Nan::Utf8String(info[1]);
     }
 
     bool result = that->impl->SetDictionary(language, directory);
@@ -47,7 +47,7 @@ class Spellchecker : public Nan::ObjectWrap {
     }
 
     Spellchecker* that = Nan::ObjectWrap::Unwrap<Spellchecker>(info.Holder());
-    std::string word = *String::Utf8Value(info[0]);
+    std::string word = *Nan::Utf8String(info[0]);
 
     info.GetReturnValue().Set(Nan::New(that->impl->IsMisspelled(word)));
   }
@@ -117,7 +117,7 @@ class Spellchecker : public Nan::ObjectWrap {
     }
 
     Spellchecker* that = Nan::ObjectWrap::Unwrap<Spellchecker>(info.Holder());
-    std::string word = *String::Utf8Value(info[0]);
+    std::string word = *Nan::Utf8String(info[0]);
 
     that->impl->Add(word);
     return;
@@ -130,7 +130,7 @@ class Spellchecker : public Nan::ObjectWrap {
     }
 
     Spellchecker* that = Nan::ObjectWrap::Unwrap<Spellchecker>(info.Holder());
-    std::string word = *String::Utf8Value(info[0]);
+    std::string word = *Nan::Utf8String(info[0]);
 
     that->impl->Remove(word);
     return;
@@ -144,7 +144,7 @@ class Spellchecker : public Nan::ObjectWrap {
 
     std::string path = ".";
     if (info.Length() > 0) {
-      std::string path = *String::Utf8Value(info[0]);
+      std::string path = *Nan::Utf8String(info[0]);
     }
 
     std::vector<std::string> dictionaries =
@@ -167,7 +167,7 @@ class Spellchecker : public Nan::ObjectWrap {
 
     Spellchecker* that = Nan::ObjectWrap::Unwrap<Spellchecker>(info.Holder());
 
-    std::string word = *String::Utf8Value(info[0]);
+    std::string word = *Nan::Utf8String(info[0]);
     std::vector<std::string> corrections =
       that->impl->GetCorrectionsForMisspelling(word);
 


### PR DESCRIPTION
The following warning at Node.js 10.

```
../src/main.cc:170:50: warning:
‘v8::String::Utf8Value::Utf8Value(v8::Local<v8::Value>)’ is deprecated:
Use Isolate version [-Wdeprecated-declarations]
     std::string word = *String::Utf8Value(info[0]);
```