### PR TITLE
Remove usage of fs.statSyncNoException, deprecated in Electron 3.0

### DIFF
--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -84,10 +84,11 @@ var getDictionaryPath = function() {
   try {
     // HACK: Special case being in an asar archive
     var unpacked = dict.replace('.asar' + path.sep, '.asar.unpacked' + path.sep);
-    if (require('fs').statSyncNoException(unpacked)) {
+    if (require('fs').statSync(unpacked)) {
       dict = unpacked;
     }
   } catch (error) {
+    // When the dictionary isn't contained within an .asar, return the original path.
   }
   return dict;
 }


### PR DESCRIPTION
This change removes the use of `fs.statSyncNoException` which was deprecated in Electron 3.0.  Since the usage of this function was already inside of a try/catch block, I've switched it to `fs.statSync`.

Fixes #105.