### PR TITLE
fix: Handle -> Local for node 12 compat

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -58,7 +58,7 @@ class Spellchecker : public Nan::ObjectWrap {
       return Nan::ThrowError("Bad argument");
     }
 
-    Handle<String> string = Handle<String>::Cast(info[0]);
+    Local<String> string = Local<String>::Cast(info[0]);
     if (!string->IsString()) {
       return Nan::ThrowError("Bad argument");
     }
@@ -94,7 +94,7 @@ class Spellchecker : public Nan::ObjectWrap {
       return Nan::ThrowError("Bad argument");
     }
 
-    Handle<String> string = Handle<String>::Cast(info[0]);
+    Local<String> string = Local<String>::Cast(info[0]);
     if (!string->IsString()) {
       return Nan::ThrowError("Bad argument");
     }
@@ -192,7 +192,7 @@ class Spellchecker : public Nan::ObjectWrap {
   }
 
  public:
-  static void Init(Handle<Object> exports) {
+  static void Init(Local<Object> exports) {
     Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(Spellchecker::New);
 
     tpl->SetClassName(Nan::New<String>("Spellchecker").ToLocalChecked());
@@ -211,7 +211,7 @@ class Spellchecker : public Nan::ObjectWrap {
   }
 };
 
-void Init(Handle<Object> exports, Handle<Object> module) {
+void Init(Local<Object> exports, Local<Object> module) {
   Spellchecker::Init(exports);
 }
 


### PR DESCRIPTION
Upcoming Node12 (and Electron 5) will ship with a V8 that finally removes `Handle` (which was deprecated some years ago.)

Ref: https://electronjs.org/blog/nodejs-native-addons-and-electron-5