### PR TITLE
Update package.json to fix nan error

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "any-promise": "^1.3.0",
-    "nan": "^2.10.0"
+    "nan": "^2.12.1"
   }
 }


### PR DESCRIPTION
Removes the nan error.

```
../../nan/nan_maybe_43_inl.h:112:15: error: no member named 'ForceSet' in 'v8::Object'
  return obj->ForceSet(isolate->GetCurrentContext(), key, value, attribs);
```