### PR TITLE
Fix CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,5 @@ env:
   global:
     - CC=clang CXX=clang++ npm_config_clang=1
   matrix:
-    - NODE_VERSION=node
+    - NODE_VERSION=8.9.3
+    - NODE_VERSION=10


### PR DESCRIPTION
As a followup of #108, this PR changes the CI builds to include on Node v8.9.3 and Node v10 (Since builds on Node v12 have started failing ([more info](https://travis-ci.org/atom/node-spellchecker/jobs/525885251)).