### PR TITLE
Switch `package.json` to use the proper `license` key.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,7 @@
   "name": "spellchecker",
   "description": "Bindings to native spellchecker",
   "version": "3.5.3",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/atom/node-spellchecker/raw/master/LICENSE.md"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/atom/node-spellchecker.git"


### PR DESCRIPTION
- Switched from old style to the SPDX version as per https://docs.npmjs.com/files/package.json#license