### PR TITLE
Enable building on FreeBSD

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,6 +7,9 @@
       ['OS=="linux"', {
         'spellchecker_use_hunspell': 'true',
       }],
+      ['OS=="freebsd"', {
+        'spellchecker_use_hunspell': 'true',
+      }],
       ['OS=="win"', {
         'spellchecker_use_hunspell': 'true',
       }],
@@ -54,6 +57,12 @@
           ],
         }],
         ['OS=="linux"', {
+          'sources': [
+             'src/spellchecker_linux.cc',
+             'src/transcoder_posix.cc',
+          ],
+        }],
+        ['OS=="freebsd"', {
           'sources': [
              'src/spellchecker_linux.cc',
              'src/transcoder_posix.cc',

--- a/vendor/hunspell/src/hunspell/affentry.hxx
+++ b/vendor/hunspell/src/hunspell/affentry.hxx
@@ -27,7 +27,7 @@ public:
   struct hentry *      checkword(const char * word, int len, char in_compound, 
                             const FLAG needflag = FLAG_NULL);
 
-  struct hentry *      check_twosfx(const char * word, int len, char in_compound, const FLAG needflag = NULL);
+  struct hentry *      check_twosfx(const char * word, int len, char in_compound, const FLAG needflag = FLAG_NULL);
 
   char *      check_morph(const char * word, int len, char in_compound,
                             const FLAG needflag = FLAG_NULL);
@@ -90,7 +90,7 @@ public:
 //                    const FLAG cclass = FLAG_NULL, const FLAG needflag = FLAG_NULL, char in_compound=IN_CPD_NOT);
                     const FLAG cclass = FLAG_NULL, const FLAG needflag = FLAG_NULL, const FLAG badflag = 0);
 
-  struct hentry *   check_twosfx(const char * word, int len, int optflags, PfxEntry* ppfx, const FLAG needflag = NULL);
+  struct hentry *   check_twosfx(const char * word, int len, int optflags, PfxEntry* ppfx, const FLAG needflag = FLAG_NULL);
 
   char *      check_twosfx_morph(const char * word, int len, int optflags,
                  PfxEntry* ppfx, const FLAG needflag = FLAG_NULL);


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Identify the Bug

Similar to #87, building is broken in FreeBSD for 2 reasons:
1. The OS is not recognized by the build system.
1. hunspell won't build cleanly under LLVM/Clang.

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

I would really like to make this change support OpenBSD as #87 reports, but given that I don't have a VM available at the moment, I limited my changes to FreeBSD (that I can test).

This PR includes 2 changes:
1. Make `freebsd` a recognizable platform alongside `mac`, `linux` and `win`. The logic is identical to Linux, since nothing special is required.
1. Partially backport https://github.com/hunspell/hunspell/commit/be3b8d945a2577fb714fee95a6499f22a7e2cef6#diff-0dd29bfd51e6c6fdadebc9b96923c5c6 and https://github.com/hunspell/hunspell/commit/dd3a71c38b614adc88d232f16fb1b199c97cf28f#diff-0dd29bfd51e6c6fdadebc9b96923c5c6. Hunspell have already fixed the build issue upstream, but the version included with spellchecker is not up to date. Instead of pulling in *all* the changes from upstream, include the must-haves that unbreak the build.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

Ideally, we could update hunspell to the latest version. However that might be a big change, given that the last time that the vendor directory was updated was 6 years ago.

With this in mind, I tried to pick the minimum amount of changes that will unbreak the build and minimize the risk of breakage.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

I am not aware of any drawbacks. Given that this is just following the upstream commits, this shouldn't have any negative impact.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Verified that the build works, and that the unit tests still pass.

```
$ yarn test
yarn run v1.16.0
$ jasmine-focused --captureExceptions --coffee spec/
..........................................................................................................................................

Finished in 13.619 seconds
138 tests, 184 assertions, 0 failures, 0 skipped


Done in 14.37s.
```
<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

- node-spellchecker can now be built under FreeBSD

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->